### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: "CI"
 # Continuous Integration workflow for testing the project
 # This workflow ensures the code works across different Python versions
 
+permissions:
+  contents: read
+
 on:
   push  # Run on every push to the repository
   #schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/tschm/pyhrp/security/code-scanning/10](https://github.com/tschm/pyhrp/security/code-scanning/10)

To fix the issue, we need to add a `permissions` block to the workflow. Since this is a basic CI pipeline, the minimal permissions required are likely `contents: read`. This ensures the workflow can access the repository contents without granting unnecessary write permissions. The `permissions` block should be added at the root level of the workflow to apply to all jobs, as there is no indication that job-specific permissions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
