### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,6 +3,9 @@ name: pre-commit
 # Workflow for code quality checks and dependency management
 # This workflow ensures code quality standards are maintained and dependencies are properly managed
 
+permissions:
+  contents: read
+
 on:
   push:  # Run on every push to the repository
 


### PR DESCRIPTION
Potential fix for [https://github.com/tschm/pyhrp/security/code-scanning/12](https://github.com/tschm/pyhrp/security/code-scanning/12)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow does not appear to require write permissions, we will set the permissions to `contents: read` at the workflow level. This ensures that the `GITHUB_TOKEN` has minimal privileges, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
