### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -10,6 +10,9 @@
 #   - 📝 Create a pull request with the changes
 
 name: SYNC
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/tschm/pyhrp/security/code-scanning/14](https://github.com/tschm/pyhrp/security/code-scanning/14)

To fix the problem, you should add a `permissions` block to the workflow. The ideal location is at either the workflow root (applies to all jobs) or the specific job level. The correct practice is to grant the least privilege necessary; for most workflows that only need to check out code and create pull requests (as suggested here), this would usually be `contents: read` and `pull-requests: write`. Place the `permissions:` block above the `jobs:` or inside the `sync:` job before `steps:`.

Because there's currently only one job, the simplest and most sweeping change is to add the block at the workflow root (just after `name: SYNC`, before `on:`). This covers all jobs in the workflow (and is immediately visible).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to enable automated pull request creation and updates alongside repository content access for continuous integration operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->