### PR TITLE
chore: update rhiza template version to v0.10.1

### DIFF
--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 template-repository: "jebel-quant/rhiza"
-template-branch: "v0.9.5"
+template-branch: "v0.10.1"
 
 templates:
   - github


### PR DESCRIPTION
## Summary
- Updates `.rhiza/template.yml` template branch from `v0.9.5` to `v0.10.1`

## Test plan
- [ ] Verify rhiza sync runs successfully with the new template version

🤖 Generated with [Claude Code](https://claude.com/claude-code)