### PR TITLE
refactor: migrate from pandas/matplotlib to polars/plotly

### DIFF
--- a/book/marimo/hrp.py
+++ b/book/marimo/hrp.py
@@ -7,6 +7,7 @@ and portfolio weights for each approach.
 """
 
 # /// script
+# requires-python = ">=3.12"
 # dependencies = [
 #     "marimo==0.18.4",
 #     "plotly",

--- a/book/marimo/hrp.py
+++ b/book/marimo/hrp.py
@@ -7,7 +7,7 @@ and portfolio weights for each approach.
 """
 
 # /// script
-# requires-python = ">=3.12"
+# requires-python = ">=3.11"
 # dependencies = [
 #     "marimo==0.18.4",
 #     "plotly",


### PR DESCRIPTION
## Summary

- Migrate core library and notebooks from pandas/matplotlib to polars/plotly
- Fix `Portfolio.weights` API to return `dict[str, float]`
- Update README examples and tests to reflect the new stack
- Remove `pyportfolioopt` dependency and related tests

## Test plan

- [ ] Run `pytest` to confirm all tests pass
- [ ] Verify marimo notebooks render correctly with polars/plotly
- [ ] Check that `Portfolio.weights` returns the correct type

🤖 Generated with [Claude Code](https://claude.com/claude-code)