### PR TITLE
docs: add Examples sections to hrp, build_tree, risk_parity, one_over_n

### DIFF
--- a/src/pyhrp/algos.py
+++ b/src/pyhrp/algos.py
@@ -34,6 +34,16 @@ def risk_parity(root: Cluster, cov: pl.DataFrame) -> Cluster:
 
     Returns:
         Cluster: The root node with portfolio weights assigned
+
+    Examples:
+        >>> import polars as pl
+        >>> from pyhrp.cluster import Cluster
+        >>> from pyhrp.algos import risk_parity
+        >>> cov = pl.DataFrame({"A": [4.0, 0.0], "B": [0.0, 1.0]})
+        >>> root = Cluster(2, left=Cluster(0), right=Cluster(1))
+        >>> cluster = risk_parity(root=root, cov=cov)
+        >>> round(cluster.portfolio["B"], 1)
+        0.8
     """
     if root.is_leaf:
         # a node is a leaf if has no further relatives downstream.
@@ -108,6 +118,16 @@ def one_over_n(dendrogram: Dendrogram) -> Generator[tuple[int, Portfolio]]:
     Yields:
         tuple[int, Portfolio]: A tuple containing the level number and the portfolio
                               at that level
+
+    Examples:
+        >>> import polars as pl
+        >>> from pyhrp.hrp import build_tree
+        >>> from pyhrp.algos import one_over_n
+        >>> cor = pl.DataFrame({"A": [1.0, 0.3], "B": [0.3, 1.0]})
+        >>> dg = build_tree(cor, method="ward")
+        >>> levels = list(one_over_n(dg))
+        >>> len(levels) > 0
+        True
     """
     root = dendrogram.root
     assets = dendrogram.assets

--- a/src/pyhrp/hrp.py
+++ b/src/pyhrp/hrp.py
@@ -61,6 +61,14 @@ def hrp(
 
     Returns:
         Cluster: The root cluster with portfolio weights assigned according to HRP
+
+    Examples:
+        >>> import polars as pl
+        >>> from pyhrp.hrp import hrp
+        >>> prices = pl.DataFrame({"A": [100.0, 101.0, 99.0, 102.0], "B": [50.0, 51.0, 49.0, 52.0]})
+        >>> root = hrp(prices, method="ward")
+        >>> round(sum(root.portfolio.weights.values()), 6)
+        1.0
     """
     returns = (
         prices.select(pl.all().pct_change())
@@ -211,6 +219,14 @@ def build_tree(
             - assets: List of assets
             - method: Clustering method used
             - distance: Distance matrix
+
+    Examples:
+        >>> import polars as pl
+        >>> from pyhrp.hrp import build_tree
+        >>> cor = pl.DataFrame({"A": [1.0, 0.5], "B": [0.5, 1.0]})
+        >>> dg = build_tree(cor, method="ward")
+        >>> dg.root.leaf_count
+        2
     """
     if not isinstance(cor, pl.DataFrame):
         raise TypeError("Correlation matrix must be a polars DataFrame.")  # noqa: TRY003


### PR DESCRIPTION
## Summary
- Adds a minimal `Examples:` block (Google docstring style) to each of the four primary public functions: `hrp`, `build_tree`, `risk_parity`, `one_over_n`
- Examples are copy-paste runnable, show the expected return type, and include one verifiable numerical assertion (e.g. weights sum to 1.0, leaf count matches input)
- Improves both the generated MkDocs API reference and in-editor hover documentation

## Test plan
- [ ] `ruff check src/` passes (no W505 or D violations)
- [ ] All 84 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added usage examples to library function docstrings, demonstrating how to construct inputs and interpret expected outputs for improved guidance on using the library.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tschm/pyhrp/pull/673?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->