### PR TITLE
ci: auto-update CHANGELOG.md after each release via git-cliff

### DIFF
--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -472,3 +472,30 @@ jobs:
 
           gh release edit "$TAG" --draft=false --notes-file /tmp/notes.md
 
+  update-changelog:
+    name: Update CHANGELOG.md
+    runs-on: ubuntu-latest
+    needs: [tag, finalise-release]
+    if: needs.finalise-release.result == 'success'
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "0.11.14"
+
+      - name: Regenerate CHANGELOG.md
+        run: uvx git-cliff --output CHANGELOG.md
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git diff --staged --quiet || git commit -m "chore: update CHANGELOG.md for ${{ needs.tag.outputs.tag }}"
+          git diff HEAD origin/main --quiet || git push origin main


### PR DESCRIPTION
## Summary
- Adds `update-changelog` job to `rhiza_release.yml`, running after `finalise-release` succeeds
- Checks out `main` (not the tag), runs `uvx git-cliff --output CHANGELOG.md`, commits and pushes if the file changed
- Skips silently if nothing changed (idempotent)
- Commit message includes the release tag (e.g. `chore: update CHANGELOG.md for v2.1.0`)

## Test plan
- [ ] YAML is structurally valid (yamllint reports no errors)
- [ ] actionlint pre-commit hook passes
- [ ] On next release tag push, CHANGELOG.md is updated automatically on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)