### PR TITLE
refactor: promote compute_cov and compute_corr to public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ Here's a simple example
 
 ```python
 import polars as pl
-from pyhrp.hrp import build_tree, _compute_cov, _compute_corr
+from pyhrp.hrp import build_tree, compute_cov, compute_corr
 from pyhrp.algos import risk_parity
 
 prices = pl.read_csv("tests/resources/stock_prices.csv", try_parse_dates=True).drop("date")
 
 returns = prices.select(pl.all().pct_change()).drop_nulls().fill_null(0.0)
-cov = _compute_cov(returns)
-cor = _compute_corr(returns)
+cov = compute_cov(returns)
+cor = compute_corr(returns)
 
 # Compute the dendrogram based on the correlation matrix and Ward's metric
 dendrogram = build_tree(cor, method='ward')

--- a/book/marimo/1_over_N.py
+++ b/book/marimo/1_over_N.py
@@ -50,12 +50,12 @@ def _():
 
 @app.cell
 def _():
-    from pyhrp.hrp import _compute_corr, _compute_cov
+    from pyhrp.hrp import compute_corr, compute_cov
 
     _prices = pl.read_csv(str(mo.notebook_location() / "public" / "stock_prices.csv"))
     returns = _prices.drop(_prices.columns[0]).select(pl.all().pct_change()).drop_nulls().fill_null(0.0)
-    cor = _compute_corr(returns)
-    cov = _compute_cov(returns)
+    cor = compute_corr(returns)
+    cov = compute_cov(returns)
     return (cor, cov, returns)
 
 

--- a/book/marimo/hrp.py
+++ b/book/marimo/hrp.py
@@ -60,10 +60,10 @@ def _():
 
 @app.cell
 def _(returns):
-    from pyhrp.hrp import _compute_corr, _compute_cov
+    from pyhrp.hrp import compute_corr, compute_cov
 
-    cor = _compute_corr(returns)
-    cov = _compute_cov(returns)
+    cor = compute_corr(returns)
+    cov = compute_cov(returns)
     return cor, cov
 
 

--- a/src/pyhrp/hrp.py
+++ b/src/pyhrp/hrp.py
@@ -20,17 +20,17 @@ import scipy.spatial.distance as ssd
 from .algos import risk_parity
 from .cluster import Cluster
 
-__all__ = ["Dendrogram", "build_tree", "hrp"]
+__all__ = ["Dendrogram", "build_tree", "compute_corr", "compute_cov", "hrp"]
 
 
-def _compute_cov(df: pl.DataFrame) -> pl.DataFrame:
+def compute_cov(df: pl.DataFrame) -> pl.DataFrame:
     """Compute covariance matrix from a DataFrame of returns."""
     cols = df.columns
     cov = np.cov(df.to_numpy().T)
     return pl.DataFrame(dict(zip(cols, cov, strict=False)))
 
 
-def _compute_corr(df: pl.DataFrame) -> pl.DataFrame:
+def compute_corr(df: pl.DataFrame) -> pl.DataFrame:
     """Compute correlation matrix from a DataFrame of returns."""
     cols = df.columns
     corr = np.corrcoef(df.to_numpy().T)
@@ -76,8 +76,8 @@ def hrp(
         .fill_null(0.0)
         .fill_nan(0.0)
     )
-    cov = _compute_cov(returns)
-    cor = _compute_corr(returns)
+    cov = compute_cov(returns)
+    cor = compute_corr(returns)
     node = node or build_tree(cor, method=method, bisection=bisection).root
 
     return risk_parity(root=node, cov=cov)

--- a/src/pyhrp/hrp.py
+++ b/src/pyhrp/hrp.py
@@ -3,6 +3,8 @@
 This module implements the core HRP algorithm and related functions:
 - hrp: Main function to compute HRP portfolio weights
 - build_tree: Function to build hierarchical cluster tree from correlation matrix
+- compute_cov: Function to compute a covariance matrix from returns
+- compute_corr: Function to compute a correlation matrix from returns
 - Dendrogram: Class to store and visualize hierarchical clustering results
 """
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -7,7 +7,7 @@ import polars as pl
 import pytest
 from pytest_benchmark.fixture import BenchmarkFixture
 
-from pyhrp.hrp import _compute_corr, build_tree, hrp
+from pyhrp.hrp import build_tree, compute_corr, hrp
 
 
 def _synthetic_prices(asset_count: int, periods: int = 500, seed: int = 0) -> pl.DataFrame:
@@ -51,7 +51,7 @@ def test_benchmark_build_tree_100_assets(benchmark: BenchmarkFixture) -> None:
     """Benchmark build_tree on 100 assets."""
     prices = _synthetic_prices(asset_count=100, seed=300)
     returns = prices.select(pl.all().pct_change()).drop_nulls()
-    cor = _compute_corr(returns)
+    cor = compute_corr(returns)
     dg = benchmark(lambda: build_tree(cor=cor, method="ward", bisection=False))
     assert dg.root.leaf_count == cor.shape[1]
 
@@ -61,6 +61,6 @@ def test_benchmark_build_tree_200_assets(benchmark: BenchmarkFixture) -> None:
     """Benchmark build_tree on 200 assets."""
     prices = _synthetic_prices(asset_count=200, seed=400)
     returns = prices.select(pl.all().pct_change()).drop_nulls()
-    cor = _compute_corr(returns)
+    cor = compute_corr(returns)
     dg = benchmark(lambda: build_tree(cor=cor, method="ward", bisection=False))
     assert dg.root.leaf_count == cor.shape[1]

--- a/tests/test_dendrogram_extras.py
+++ b/tests/test_dendrogram_extras.py
@@ -13,7 +13,7 @@ import polars as pl
 import pytest
 
 from pyhrp.cluster import Cluster
-from pyhrp.hrp import Dendrogram, _compute_corr, _compute_distance_matrix, build_tree, hrp
+from pyhrp.hrp import Dendrogram, _compute_distance_matrix, build_tree, compute_corr, hrp
 
 
 def test_dendrogram_plot_executes(returns: pl.DataFrame) -> None:
@@ -22,14 +22,14 @@ def test_dendrogram_plot_executes(returns: pl.DataFrame) -> None:
     We build a dendrogram from a correlation matrix and call plot.
     No figure is shown; we just ensure the function runs.
     """
-    cor = _compute_corr(returns)
+    cor = compute_corr(returns)
     dendrogram = build_tree(cor=cor, method="single", bisection=False)
     dendrogram.plot()
 
 
 def test_dendrogram_plot_with_kwargs(returns: pl.DataFrame) -> None:
     """Test Dendrogram.plot with custom kwargs."""
-    cor = _compute_corr(returns)
+    cor = compute_corr(returns)
     dendrogram = build_tree(cor=cor, method="single", bisection=False)
     dendrogram.plot(color_threshold=0.5, above_threshold_color="red")
 
@@ -140,7 +140,7 @@ def test_build_tree_with_three_assets() -> None:
 @pytest.mark.parametrize("method", ["single", "complete", "average", "ward"])
 def test_build_tree_with_different_methods(returns: pl.DataFrame, method: str) -> None:
     """Test build_tree with all supported linkage methods."""
-    cor = _compute_corr(returns)
+    cor = compute_corr(returns)
     dendrogram = build_tree(cor=cor, method=method, bisection=False)
 
     assert dendrogram.root is not None
@@ -151,7 +151,7 @@ def test_build_tree_with_different_methods(returns: pl.DataFrame, method: str) -
 
 def test_build_tree_bisection_true(returns: pl.DataFrame) -> None:
     """Test build_tree with bisection enabled."""
-    cor = _compute_corr(returns)
+    cor = compute_corr(returns)
     dendrogram = build_tree(cor=cor, method="single", bisection=True)
 
     assert dendrogram.root is not None
@@ -237,7 +237,7 @@ def test_hrp_without_node(prices: pl.DataFrame) -> None:
 
 def test_hrp_with_node(prices: pl.DataFrame, returns: pl.DataFrame) -> None:
     """Test hrp function with a pre-built node."""
-    cor = _compute_corr(returns)
+    cor = compute_corr(returns)
     dendrogram = build_tree(cor=cor, method="ward", bisection=False)
 
     result = hrp(prices=prices, node=dendrogram.root, method="ward", bisection=False)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -6,12 +6,12 @@ import numpy as np
 import pytest
 from polars import DataFrame
 
-from pyhrp.hrp import _compute_corr, _compute_cov
+from pyhrp.hrp import compute_corr, compute_cov
 
 
 def test_compute_cov_matrix_properties(returns: DataFrame) -> None:
     """Test covariance helper returns a symmetric square matrix with matching columns."""
-    cov = _compute_cov(returns)
+    cov = compute_cov(returns)
     n_assets = len(returns.columns)
 
     assert cov.shape == (n_assets, n_assets)
@@ -21,7 +21,7 @@ def test_compute_cov_matrix_properties(returns: DataFrame) -> None:
 
 def test_compute_corr_matrix_properties(returns: DataFrame) -> None:
     """Test correlation helper returns a square matrix with unit diagonal and matching columns."""
-    corr = _compute_corr(returns)
+    corr = compute_corr(returns)
     n_assets = len(returns.columns)
 
     assert corr.shape == (n_assets, n_assets)

--- a/tests/test_hrp.py
+++ b/tests/test_hrp.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 from polars import DataFrame
 
-from pyhrp.hrp import _bisect_tree, _compute_corr, _get_linkage, build_tree
+from pyhrp.hrp import _bisect_tree, _get_linkage, build_tree, compute_corr
 
 
 def test_linkage(returns: DataFrame, resource_dir: Path) -> None:
@@ -20,7 +20,7 @@ def test_linkage(returns: DataFrame, resource_dir: Path) -> None:
         returns: DataFrame of asset returns
         resource_dir: Path to test resources directory
     """
-    dendrogram = build_tree(cor=_compute_corr(returns), method="single", bisection=False)
+    dendrogram = build_tree(cor=compute_corr(returns), method="single", bisection=False)
 
     assert dendrogram.ids == [11, 7, 19, 6, 14, 5, 10, 13, 3, 1, 4, 16, 0, 2, 17, 9, 8, 18, 12, 15]
 
@@ -37,7 +37,7 @@ def test_bisection(returns: DataFrame, resource_dir: Path) -> None:
         returns: DataFrame of asset returns
         resource_dir: Path to test resources directory
     """
-    dendrogram = build_tree(cor=_compute_corr(returns), method="single", bisection=True)
+    dendrogram = build_tree(cor=compute_corr(returns), method="single", bisection=True)
 
     assert dendrogram.ids == [11, 7, 19, 6, 14, 5, 10, 13, 3, 1, 4, 16, 0, 2, 17, 9, 8, 18, 12, 15]
 
@@ -53,7 +53,7 @@ def test_plot_bisection(returns: DataFrame) -> None:
     Args:
         returns: DataFrame of asset returns
     """
-    cor = _compute_corr(returns)
+    cor = compute_corr(returns)
     dendrogram = build_tree(cor=cor, method="single", bisection=True)
 
     assert dendrogram.root is not None
@@ -95,7 +95,7 @@ def test_invariant_order(returns: DataFrame, method: str) -> None:
         returns: DataFrame of asset returns
         method: Clustering method to use (single, ward, average, or complete)
     """
-    cor = _compute_corr(returns)
+    cor = compute_corr(returns)
     dendrogram1 = build_tree(cor=cor, method=method, bisection=True)
     dendrogram2 = build_tree(cor=cor, method=method, bisection=False)
 

--- a/tests/test_large_1n.py
+++ b/tests/test_large_1n.py
@@ -5,7 +5,7 @@ from polars import DataFrame
 
 from pyhrp.algos import one_over_n
 from pyhrp.cluster import Portfolio
-from pyhrp.hrp import _compute_corr, build_tree
+from pyhrp.hrp import build_tree, compute_corr
 
 
 def test_one_over_n_large(returns: DataFrame) -> None:
@@ -21,7 +21,7 @@ def test_one_over_n_large(returns: DataFrame) -> None:
     Args:
         returns: DataFrame of asset returns
     """
-    cor = _compute_corr(returns)
+    cor = compute_corr(returns)
     dendrogram = build_tree(cor=cor, method="ward")
 
     portfolios: list[tuple[int, Portfolio]] = list(one_over_n(dendrogram))


### PR DESCRIPTION
## Summary

- Rename `_compute_cov` → `compute_cov` and `_compute_corr` → `compute_corr` in `src/pyhrp/hrp.py`
- Add both to `__all__` so they are part of the documented public API
- Update all call-sites: tests, marimo notebooks, and README

## Test plan

- [ ] All 83 existing tests pass (`uv run pytest tests/`)
- [ ] No regressions — only identifier renames, no logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * compute_cov and compute_corr are now public APIs for computing covariance and correlation matrices from returns data.

* **Documentation**
  * README and example notebooks updated to show usage of the new public functions.

* **Tests**
  * Test suite updated to use and validate the public correlation/covariance helpers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tschm/pyhrp/pull/676?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->