### PR TITLE
feat: Schur Complementary Allocation

### DIFF
--- a/src/pyhrp/algos.py
+++ b/src/pyhrp/algos.py
@@ -11,6 +11,7 @@ from collections.abc import Generator
 from copy import deepcopy
 from typing import TYPE_CHECKING
 
+import numpy as np
 import polars as pl
 
 from .cluster import Cluster, Portfolio
@@ -18,7 +19,7 @@ from .cluster import Cluster, Portfolio
 if TYPE_CHECKING:
     from .hrp import Dendrogram
 
-__all__ = ["one_over_n", "risk_parity"]
+__all__ = ["one_over_n", "risk_parity", "schur_risk_parity"]
 
 
 def risk_parity(root: Cluster, cov: pl.DataFrame) -> Cluster:
@@ -100,6 +101,93 @@ def _parity(cluster: Cluster, cov: pl.DataFrame) -> Cluster:
     # Assign the combined weights to the parent cluster's portfolio
     for asset, weight in assets.items():
         cluster.portfolio[asset] = weight
+
+    return cluster
+
+
+def schur_risk_parity(root: Cluster, cov: pl.DataFrame, gamma: float = 0.5) -> Cluster:
+    """Compute Schur Complementary Allocation weights for a cluster tree.
+
+    An extension of HRP introduced by Peter Cotton (arXiv:2411.05807) that augments
+    sub-covariance matrices with off-diagonal block information via Schur complements.
+    At gamma=0 this recovers standard HRP; at gamma=1 it recovers the minimum-variance
+    portfolio through the same recursive structure.
+
+    Args:
+        root (Cluster): The root node of the cluster tree
+        cov (pl.DataFrame): Covariance matrix of asset returns
+        gamma (float): Interpolation parameter in [0, 1]. 0 = HRP, 1 = minimum variance.
+
+    Returns:
+        Cluster: The root node with portfolio weights assigned
+
+    Examples:
+        >>> import polars as pl
+        >>> from pyhrp.cluster import Cluster
+        >>> from pyhrp.algos import schur_risk_parity
+        >>> cov = pl.DataFrame({"A": [4.0, 0.0], "B": [0.0, 1.0]})
+        >>> root = Cluster(2, left=Cluster(0), right=Cluster(1))
+        >>> cluster = schur_risk_parity(root=root, cov=cov, gamma=0.5)
+        >>> round(cluster.portfolio["B"], 1)
+        0.8
+    """
+    if root.is_leaf:
+        asset = cov.columns[int(root.value)]
+        root.portfolio[asset] = 1.0
+        return root
+
+    if not isinstance(root.left, Cluster):
+        raise TypeError("Expected left child to be a Cluster")  # noqa: TRY003
+    if not isinstance(root.right, Cluster):
+        raise TypeError("Expected right child to be a Cluster")  # noqa: TRY003
+    root.left = schur_risk_parity(root.left, cov, gamma)
+    root.right = schur_risk_parity(root.right, cov, gamma)
+
+    return _schur_parity(root, cov=cov, gamma=gamma)
+
+
+def _schur_parity(cluster: Cluster, cov: pl.DataFrame, gamma: float) -> Cluster:
+    """Compute Schur-augmented risk parity weights for a parent cluster.
+
+    Replaces sub-covariance blocks a_mat and d_mat with Schur complements
+    a_aug = a_mat - gamma * b_mat @ inv(d_mat) @ b_mat.T and
+    d_aug = d_mat - gamma * b_mat.T @ inv(a_mat) @ b_mat before splitting risk.
+    This incorporates cross-group covariance information that standard HRP discards.
+    """
+    if not isinstance(cluster.left, Cluster):
+        raise TypeError("Expected left child to be a Cluster")  # noqa: TRY003
+    if not isinstance(cluster.right, Cluster):
+        raise TypeError("Expected right child to be a Cluster")  # noqa: TRY003
+
+    left_assets = cluster.left.portfolio.assets
+    right_assets = cluster.right.portfolio.assets
+
+    cov_np = cov.to_numpy()
+    cols = cov.columns
+    li = [cols.index(a) for a in left_assets]
+    ri = [cols.index(a) for a in right_assets]
+
+    a_mat = cov_np[np.ix_(li, li)]
+    b_mat = cov_np[np.ix_(li, ri)]
+    d_mat = cov_np[np.ix_(ri, ri)]
+
+    w_left = np.array([cluster.left.portfolio[a] for a in left_assets])
+    w_right = np.array([cluster.right.portfolio[a] for a in right_assets])
+
+    # Schur-augmented blocks: condition each group on the other
+    a_aug = a_mat - gamma * (b_mat @ np.linalg.solve(d_mat, b_mat.T))
+    d_aug = d_mat - gamma * (b_mat.T @ np.linalg.solve(a_mat, b_mat))
+
+    v_left = float(w_left @ a_aug @ w_left)
+    v_right = float(w_right @ d_aug @ w_right)
+
+    alpha_left = v_right / (v_left + v_right)
+    alpha_right = 1.0 - alpha_left
+
+    for asset, weight in cluster.left.portfolio.weights.items():
+        cluster.portfolio[asset] = alpha_left * weight
+    for asset, weight in cluster.right.portfolio.weights.items():
+        cluster.portfolio[asset] = alpha_right * weight
 
     return cluster
 

--- a/src/pyhrp/hrp.py
+++ b/src/pyhrp/hrp.py
@@ -17,10 +17,10 @@ import polars as pl
 import scipy.cluster.hierarchy as sch
 import scipy.spatial.distance as ssd
 
-from .algos import risk_parity
+from .algos import risk_parity, schur_risk_parity
 from .cluster import Cluster
 
-__all__ = ["Dendrogram", "build_tree", "compute_corr", "compute_cov", "hrp"]
+__all__ = ["Dendrogram", "build_tree", "compute_corr", "compute_cov", "hrp", "schur_hrp"]
 
 
 def compute_cov(df: pl.DataFrame) -> pl.DataFrame:
@@ -81,6 +81,53 @@ def hrp(
     node = node or build_tree(cor, method=method, bisection=bisection).root
 
     return risk_parity(root=node, cov=cov)
+
+
+def schur_hrp(
+    prices: pl.DataFrame,
+    node: Cluster | None = None,
+    method: Literal["single", "complete", "average", "ward"] = "ward",
+    bisection: bool = False,
+    gamma: float = 0.5,
+) -> Cluster:
+    """Compute Schur Complementary Allocation portfolio weights.
+
+    Extends HRP by augmenting each sub-covariance block with off-diagonal information
+    via Schur complements before splitting risk between clusters. Introduced by Peter Cotton
+    (arXiv:2411.05807). At gamma=0 this is identical to HRP; at gamma=1 it recovers the
+    global minimum-variance portfolio through the same recursive hierarchy.
+
+    Args:
+        prices (pl.DataFrame): Asset price time series (columns are assets, rows are dates)
+        node (Cluster, optional): Root node of the hierarchical clustering tree.
+            If None, a tree will be built from the correlation matrix.
+        method (Literal["single", "complete", "average", "ward"]): Linkage method for clustering
+        bisection (bool): Whether to use bisection method for tree construction
+        gamma (float): Schur interpolation parameter in [0, 1].
+            0 recovers standard HRP; 1 recovers minimum-variance portfolio.
+
+    Returns:
+        Cluster: The root cluster with portfolio weights assigned
+
+    Examples:
+        >>> import polars as pl
+        >>> from pyhrp.hrp import schur_hrp
+        >>> prices = pl.DataFrame({"A": [100.0, 101.0, 99.0, 102.0], "B": [50.0, 51.0, 49.0, 52.0]})
+        >>> root = schur_hrp(prices, method="ward", gamma=0.5)
+        >>> round(sum(root.portfolio.weights.values()), 6)
+        1.0
+    """
+    returns = (
+        prices.select(pl.all().pct_change())
+        .filter(pl.any_horizontal(pl.all().is_not_null()))
+        .fill_null(0.0)
+        .fill_nan(0.0)
+    )
+    cov = compute_cov(returns)
+    cor = compute_corr(returns)
+    node = node or build_tree(cor, method=method, bisection=bisection).root
+
+    return schur_risk_parity(root=node, cov=cov, gamma=gamma)
 
 
 @dataclass(frozen=True)

--- a/tests/test_schur.py
+++ b/tests/test_schur.py
@@ -1,0 +1,109 @@
+"""Tests for Schur Complementary Allocation (Peter Cotton, arXiv:2411.05807)."""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from polars import DataFrame
+
+from pyhrp.algos import risk_parity, schur_risk_parity
+from pyhrp.cluster import Cluster
+from pyhrp.hrp import build_tree, compute_corr, compute_cov, hrp, schur_hrp
+
+
+def test_schur_weights_sum_to_one(prices: DataFrame) -> None:
+    """Portfolio weights must sum to 1."""
+    cluster = schur_hrp(prices=prices, method="ward", gamma=0.5)
+    total = sum(cluster.portfolio.weights.values())
+    assert total == pytest.approx(1.0, rel=1e-6)
+
+
+def test_gamma_zero_matches_hrp(prices: DataFrame) -> None:
+    """At gamma=0, Schur HRP must produce the same weights as standard HRP."""
+    cov = compute_cov(
+        prices.select(pl.all().pct_change())
+        .filter(pl.any_horizontal(pl.all().is_not_null()))
+        .fill_null(0.0)
+        .fill_nan(0.0)
+    )
+    cor = compute_corr(
+        prices.select(pl.all().pct_change())
+        .filter(pl.any_horizontal(pl.all().is_not_null()))
+        .fill_null(0.0)
+        .fill_nan(0.0)
+    )
+    root_hrp = build_tree(cor, method="ward").root
+    root_schur = build_tree(cor, method="ward").root
+
+    hrp_cluster = risk_parity(root=root_hrp, cov=cov)
+    schur_cluster = schur_risk_parity(root=root_schur, cov=cov, gamma=0.0)
+
+    for asset in hrp_cluster.portfolio.assets:
+        assert hrp_cluster.portfolio[asset] == pytest.approx(schur_cluster.portfolio[asset], rel=1e-6)
+
+
+def test_schur_reduces_variance_vs_hrp(prices: DataFrame) -> None:
+    """Schur HRP with gamma>0 should produce equal or lower variance than standard HRP."""
+    returns = (
+        prices.select(pl.all().pct_change())
+        .filter(pl.any_horizontal(pl.all().is_not_null()))
+        .fill_null(0.0)
+        .fill_nan(0.0)
+    )
+    cov = compute_cov(returns)
+
+    hrp_cluster = hrp(prices=prices, method="ward")
+    schur_cluster = schur_hrp(prices=prices, method="ward", gamma=1.0)
+
+    v_hrp = hrp_cluster.portfolio.variance(cov)
+    v_schur = schur_cluster.portfolio.variance(cov)
+
+    assert v_schur <= v_hrp + 1e-10
+
+
+def test_all_weights_positive(prices: DataFrame) -> None:
+    """All portfolio weights must be strictly positive (no short positions)."""
+    cluster = schur_hrp(prices=prices, method="ward", gamma=0.5)
+    for asset, w in cluster.portfolio.weights.items():
+        assert w > 0.0, f"Weight for {asset} is non-positive: {w}"
+
+
+@pytest.mark.parametrize("gamma", [0.0, 0.25, 0.5, 0.75, 1.0])
+def test_weights_sum_to_one_for_all_gamma(prices: DataFrame, gamma: float) -> None:
+    """Weights sum to 1 for all gamma values."""
+    cluster = schur_hrp(prices=prices, method="ward", gamma=gamma)
+    assert sum(cluster.portfolio.weights.values()) == pytest.approx(1.0, rel=1e-6)
+
+
+def test_schur_two_assets() -> None:
+    """Verify Schur complement on a 2-asset portfolio reduces to known formula."""
+    # cov = [[4, 1], [1, 1]] — a=4, d=1, b=1
+    # a_aug = 4 - gamma * 1 * 1/1 * 1 = 4 - gamma
+    # d_aug = 1 - gamma * 1 * 1/4 * 1 = 1 - gamma/4
+    cov = pl.DataFrame({"A": [4.0, 1.0], "B": [1.0, 1.0]})
+    gamma = 0.8
+
+    root = Cluster(2, left=Cluster(0), right=Cluster(1))
+    cluster = schur_risk_parity(root=root, cov=cov, gamma=gamma)
+
+    a_aug = 4.0 - gamma * 1.0
+    d_aug = 1.0 - gamma * 0.25
+    alpha_left = d_aug / (a_aug + d_aug)
+    alpha_right = a_aug / (a_aug + d_aug)
+
+    assert cluster.portfolio["A"] == pytest.approx(alpha_left, rel=1e-10)
+    assert cluster.portfolio["B"] == pytest.approx(alpha_right, rel=1e-10)
+
+
+def test_schur_accepts_custom_node(prices: DataFrame) -> None:
+    """schur_hrp accepts a pre-built node and uses it."""
+    returns = (
+        prices.select(pl.all().pct_change())
+        .filter(pl.any_horizontal(pl.all().is_not_null()))
+        .fill_null(0.0)
+        .fill_nan(0.0)
+    )
+    cor = compute_corr(returns)
+    node = build_tree(cor, method="single").root
+    cluster = schur_hrp(prices=prices, node=node, gamma=0.5)
+    assert sum(cluster.portfolio.weights.values()) == pytest.approx(1.0, rel=1e-6)


### PR DESCRIPTION
## Summary

- Adds `schur_risk_parity(root, cov, gamma)` in `algos.py`: mirrors `risk_parity` but augments sub-covariance blocks with off-diagonal information via Schur complements before splitting risk between clusters
- Adds `schur_hrp(prices, node, method, bisection, gamma)` in `hrp.py`: drop-in companion to `hrp()` with an extra `gamma` parameter
- Both are exported from `hrp.py`'s `__all__`

**How it works:** At each bisection step the covariance splits into blocks A (left), D (right), B (cross). Standard HRP discards B. Schur HRP replaces A and D with `a_aug = A - gamma * B @ inv(D) @ B.T` and `d_aug = D - gamma * B.T @ inv(A) @ B` before computing the risk split. At `gamma=0` the result is identical to HRP; at `gamma=1` it recovers the global minimum-variance portfolio through the same recursive structure.

Reference: Peter Cotton, *Schur Complementary Allocation: A Unification of Hierarchical Risk Parity and Minimum Variance Portfolios*, [arXiv:2411.05807](https://arxiv.org/abs/2411.05807)

## Test plan

- [ ] `test_gamma_zero_matches_hrp` — exact numerical match with standard HRP at gamma=0
- [ ] `test_schur_reduces_variance_vs_hrp` — gamma=1 produces equal or lower portfolio variance
- [ ] `test_all_weights_positive` — no short positions
- [ ] `test_weights_sum_to_one_for_all_gamma` — parametrized over 0.0, 0.25, 0.5, 0.75, 1.0
- [ ] `test_schur_two_assets` — closed-form verification against the Schur complement formula
- [ ] `test_schur_accepts_custom_node` — pre-built node is respected
- [ ] Full existing test suite unchanged (96 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Schur Hierarchical Risk Parity (Schur HRP): a configurable portfolio optimizer (gamma parameter) that generalizes standard HRP and adjusts parent-cluster allocations for improved risk allocation.
  * Accepts an optional pre-built clustering tree; produces normalized, strictly positive weights.

* **Bug Fixes / Improvements**
  * For gamma>0, often yields equal or lower portfolio variance versus standard HRP.

* **Tests**
  * Added behavioral tests validating sums-to-one, positivity, edge cases, and analytical two-asset behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tschm/pyhrp/pull/677?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->