### PR TITLE
chore: update marimo notebooks to v0.23.6

### DIFF
--- a/book/marimo/1_over_N.py
+++ b/book/marimo/1_over_N.py
@@ -20,7 +20,7 @@ and applies the 1/N strategy level by level, from the root to the leaves.
 
 import marimo
 
-__generated_with = "0.16.5"
+__generated_with = "0.23.6"
 app = marimo.App()
 
 with app.setup:
@@ -32,8 +32,7 @@ with app.setup:
 
 @app.cell
 def _():
-    mo.md(
-        r"""
+    mo.md(r"""
     # 1 over N (the hierarchical version)
 
     Inspired by Thomas Raffinot
@@ -43,8 +42,7 @@ def _():
     - Apply the methods level by level. Go from level 0 (only the root),
       to level 1 (left and right of the root), to level 2 (...)
     - On level n evaluate the function f for all leaves for each node.
-    """
-    )
+    """)
     return
 
 
@@ -55,8 +53,8 @@ def _():
     _prices = pl.read_csv(str(mo.notebook_location() / "public" / "stock_prices.csv"))
     returns = _prices.drop(_prices.columns[0]).select(pl.all().pct_change()).drop_nulls().fill_null(0.0)
     cor = compute_corr(returns)
-    cov = compute_cov(returns)
-    return (cor, cov, returns)
+    compute_cov(returns)
+    return (cor,)
 
 
 @app.cell

--- a/book/marimo/hrp.py
+++ b/book/marimo/hrp.py
@@ -22,7 +22,7 @@ and portfolio weights for each approach.
 
 import marimo
 
-__generated_with = "0.14.16"
+__generated_with = "0.23.6"
 app = marimo.App()
 
 with app.setup:
@@ -35,8 +35,7 @@ with app.setup:
 
 @app.cell
 def _():
-    mo.md(
-        r"""
+    mo.md(r"""
     # Hierarchical Risk Parity (HRP)
 
     We follow ideas by Marcos Lopez de Prado.
@@ -45,8 +44,7 @@ def _():
     - Compute the 2nd dendrogram by using the order of leaves
       of the 1st dendrogram (following an argument by Thomas Raffinot)
     - Apply Risk Parity in a recursive bottom-up traverse
-    """
-    )
+    """)
     return
 
 
@@ -54,8 +52,7 @@ def _():
 def _():
     _prices = pl.read_csv(str(mo.notebook_location() / "public" / "stock_prices.csv"))
     returns = _prices.drop(_prices.columns[0]).select(pl.all().pct_change()).drop_nulls().fill_null(0.0)
-    column_names = returns.columns
-    return column_names, returns
+    return (returns,)
 
 
 @app.cell


### PR DESCRIPTION
## Summary

- Bumps `__generated_with` from 0.14.16 / 0.16.5 to 0.23.6 in both marimo notebooks
- Minor formatting cleanup auto-applied by the new marimo version (multiline `mo.md` calls, return tuple style)

## Test plan

- [ ] Notebooks open and run correctly in marimo 0.23.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined data processing in sample notebooks to reduce unnecessary computations and improve efficiency by simplifying data dependencies.

* **Chores**
  * Updated notebook versions to 0.23.6 with minor formatting adjustments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tschm/pyhrp/pull/678?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->