### PR TITLE
refactor: remove cvx-linalg dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ authors = [{name = "Thomas Schmelzer", email = "thomas.schmelzer@gmail.com"}]
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "cvx-linalg>=0.5.1,<1",
     "numpy>=2.3,<3",
     "plotly>=5,<7",
     "polars>=1.40.1,<2",
@@ -40,6 +39,6 @@ packages = ["src/pyhrp"]
 fail_under = 90
 
 [tool.deptry]
-package_module_name_map = {"cvx-linalg" = "cvx", numpy = "numpy", scipy = "scipy", marimo = "marimo", polars = "polars", plotly = "plotly"}
+package_module_name_map = {numpy = "numpy", scipy = "scipy", marimo = "marimo", polars = "polars", plotly = "plotly"}
 ignore = ["DEP004"]
 extend_exclude = [".rhiza"]

--- a/src/pyhrp/cluster.py
+++ b/src/pyhrp/cluster.py
@@ -12,7 +12,6 @@ from dataclasses import dataclass, field
 import numpy as np
 import plotly.graph_objects as go
 import polars as pl
-from cvx.linalg import a_norm
 
 from .treelib import Node
 
@@ -57,7 +56,7 @@ class Portfolio:
         cov_matrix = cov.to_numpy()
         c = cov_matrix[np.ix_(row_indices, row_indices)]
         w = np.array([self._weights[a] for a in assets])
-        return float(a_norm(w, c) ** 2)
+        return float(w @ c @ w)
 
     def __getitem__(self, item: str) -> float:
         """Return the weight for a given asset.

--- a/uv.lock
+++ b/uv.lock
@@ -108,19 +108,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cvx-linalg"
-version = "0.6.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-    { name = "polars" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/40/b4/8704cc758c5b3a43ed82050c5cc77a01922c34517adde4688f02caf09cab/cvx_linalg-0.6.1.tar.gz", hash = "sha256:cbc87ba185a2482df7e638b39ba9f5f656fdda46d4a227b244ca3d61a7b29c6c", size = 20695, upload-time = "2026-05-20T11:45:03.513Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/2d/5393709cd1df83bb8486d25fd8a5c91fc5c3f39ea8e81c1cb2c5193e472c/cvx_linalg-0.6.1-py3-none-any.whl", hash = "sha256:5fb2f6a322117f8426536164ac397de4ab5ee3c9249b66ebfc001f3e4156f685", size = 23501, upload-time = "2026-05-20T11:45:02.316Z" },
-]
-
-[[package]]
 name = "docutils"
 version = "0.22.4"
 source = { registry = "https://pypi.org/simple" }
@@ -622,7 +609,6 @@ name = "pyhrp"
 version = "2.2.0"
 source = { editable = "." }
 dependencies = [
-    { name = "cvx-linalg" },
     { name = "numpy" },
     { name = "plotly" },
     { name = "polars" },
@@ -639,7 +625,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cvx-linalg", specifier = ">=0.5.1,<1" },
     { name = "numpy", specifier = ">=2.3,<3" },
     { name = "plotly", specifier = ">=5,<7" },
     { name = "polars", specifier = ">=1.40.1,<2" },


### PR DESCRIPTION
## Summary

- Replaces `a_norm(w, c) ** 2` from cvx-linalg with the equivalent numpy quadratic form `w @ c @ w`
- Removes `cvx-linalg` from `pyproject.toml` dependencies and `deptry` name map
- Updates `uv.lock` accordingly

## Test plan

- [x] All 103 existing tests pass (`uv run pytest`)
- [x] Pre-commit hooks pass (ruff, bandit, interrogate, uv-lock, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed external linear algebra dependency and refactored portfolio variance calculation to use NumPy matrix operations directly.

* **Chores**
  * Updated dependency mapping configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tschm/pyhrp/pull/688?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->