### PR TITLE
chore: update rhiza to v0.16.0

### DIFF
--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v0.14.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v0.16.0
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -21,5 +21,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v0.14.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v0.16.0
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -29,5 +29,5 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v0.14.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v0.16.0
     secrets: inherit

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v0.14.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v0.16.0
     secrets: inherit

--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -79,6 +79,6 @@ permissions:
 
 jobs:
   release:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_release.yml@v0.14.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_release.yml@v0.16.0
     secrets: inherit
 

--- a/.github/workflows/rhiza_sync.yml
+++ b/.github/workflows/rhiza_sync.yml
@@ -36,7 +36,7 @@ on:
 
 jobs:
   sync:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v0.14.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v0.16.0
     with:
       direct: ${{ github.event_name == 'push' }}
       create-pr: ${{ github.event_name != 'push' && (github.event_name == 'schedule' || inputs.create-pr == true) }}

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v0.14.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v0.16.0
     secrets: inherit

--- a/.rhiza/make.d/book.mk
+++ b/.rhiza/make.d/book.mk
@@ -45,7 +45,7 @@ _book-notebooks:
 # refuses to serve gitignored directories like _book) is not needed.
 serve: book ## build and serve the book at http://localhost:8000
 	@printf "${BLUE}[INFO] Serving book at http://localhost:8000 (Ctrl-C to stop)${RESET}\n"
-	@cd $(BOOK_OUTPUT) && python3 -m http.server 8000
+	@cd "$(BOOK_OUTPUT)" && ${UV_BIN} run python -m http.server 8000
 
 book:: _book-reports _book-notebooks ## compile the companion book via MkDocs
 	@rm -rf "$(BOOK_OUTPUT)"

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,7 +1,7 @@
-sha: 4051814fc1976da3a86cefa499be5bada21eb674
+sha: 86f6542c8fef07f688e79d7c4fe46cdf22cbecf9
 repo: jebel-quant/rhiza
 host: github
-ref: v0.15.3
+ref: v0.16.0
 include: []
 exclude: []
 templates:
@@ -107,5 +107,5 @@ files:
 - ruff.toml
 profiles:
 - github-project
-synced_at: '2026-05-26T14:44:41Z'
+synced_at: '2026-05-27T09:53:06Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 template-repository: "jebel-quant/rhiza"
-template-branch: "v0.15.3"
+template-branch: "v0.16.0"
 
 profiles:
   - github-project

--- a/.rhiza/tests/api/test_makefile_targets.py
+++ b/.rhiza/tests/api/test_makefile_targets.py
@@ -181,6 +181,12 @@ class TestMakefile:
         out = proc.stdout
         assert '--fail-on="MIT;Apache"' in out
 
+    def test_serve_target_uses_uv_run_python_http_server(self, logger):
+        """Serve target should use uv run instead of directly calling python3."""
+        proc = run_make(logger, ["serve"])
+        out = proc.stdout
+        assert "uv run python -m http.server 8000" in out
+
 
 class TestMakefileRootFixture:
     """Tests for root fixture usage in Makefile tests."""


### PR DESCRIPTION
## Summary

- Bumps `template-branch` to `v0.16.0` in `.rhiza/template.yml`
- Bumps `.rhiza/.rhiza-version` to `0.16.1`
- Runs `make sync` to apply upstream template changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to use version v0.16.0 of upstream implementations.
  * Updated template version to v0.16.0.
  * Improved the build server invocation to use package manager integration.

* **Tests**
  * Added test coverage for build server functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tschm/pyhrp/pull/689?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->