### PR TITLE
chore: update rhiza to v0.17.0 and resolve merge conflicts

### DIFF
--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -1,6 +1,17 @@
 # This file is part of the jebel-quant/rhiza repository
 # (https://github.com/jebel-quant/rhiza).
 #
+# ⚠️  WHY THIS WORKFLOW CANNOT USE A STUB
+#
+# Rhiza normally distributes workflows as thin stubs that delegate to a reusable
+# workflow in this repository via `workflow_call`. That pattern cannot be used here
+# because PyPI Trusted Publishing (OIDC) validates the *exact* workflow file path
+# and repository that invokes `pypa/gh-action-pypi-publish`. When a stub delegates
+# to a reusable workflow in jebel-quant/rhiza, PyPI sees rhiza's repository as the
+# publisher — not the downstream project's — and rejects the OIDC token. This file
+# must therefore be synced directly into each downstream project so that the publish
+# step runs under the correct repository identity.
+#
 # Release Workflow for Python Packages with Optional Devcontainer Publishing
 #
 # This workflow implements a secure, maintainable release pipeline with distinct phases:
@@ -70,6 +81,19 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Version tag to release (e.g. v1.2.3). Required when called via workflow_call.'
+        required: true
+        type: string
+    secrets:
+      GH_PAT:
+        required: false
+      UV_EXTRA_INDEX_URL:
+        required: false
+      PYPI_TOKEN:
+        required: false
 
 permissions:
   contents: write       # Needed to create releases
@@ -78,7 +102,431 @@ permissions:
   attestations: write   # Needed for SLSA provenance attestations (public repos only)
 
 jobs:
-  release:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_release.yml@v0.16.0
-    secrets: inherit
+  tag:
+    name: Validate Tag
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.set_tag.outputs.tag }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set Tag Variable
+        id: set_tag
+        run: |
+          if [[ -n "${{ inputs.tag }}" ]]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Validate Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.set_tag.outputs.tag }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            DRAFT_STATUS=$(gh release view "$TAG" --json isDraft --jq '.isDraft')
+            if [ "$DRAFT_STATUS" != "true" ]; then
+              echo "::error::Release '$TAG' already exists and is not a draft. Please use a new tag."
+              exit 1
+            else
+              echo "::warning::Release '$TAG' exists as a draft. Will proceed to update it."
+            fi
+          fi
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: tag
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7.6.0
+        with:
+          version: "0.11.16"
+
+      - name: Configure git auth for private packages
+        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v0.15.2
+        with:
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Verify version matches tag
+        if: hashFiles('pyproject.toml') != ''
+        run: |
+          TAG_VERSION="${{ needs.tag.outputs.tag }}"
+          TAG_VERSION=${TAG_VERSION#v}
+          PROJECT_VERSION=$(uv version --short)
+
+          # Normalize tag version to PEP 440 format for comparison.
+          # Tags use semver format (e.g., 0.11.1-beta.1) while uv version --short
+          # returns PEP 440 normalized format (e.g., 0.11.1b1).
+          NORMALIZED_TAG=$(uv run --with packaging --no-project python3 -c "from packaging.version import Version; print(Version('$TAG_VERSION'))")
+
+          if [[ "$PROJECT_VERSION" != "$NORMALIZED_TAG" ]]; then
+            echo "::error::Version mismatch: pyproject.toml has '$PROJECT_VERSION' but tag is '$NORMALIZED_TAG' (from tag '$TAG_VERSION')"
+            exit 1
+          fi
+          echo "Version verified: $PROJECT_VERSION matches tag (normalized: $NORMALIZED_TAG)"
+
+      - name: Detect buildable Python package
+        id: buildable
+        run: |
+          if [[ -f pyproject.toml ]] && grep -q '^\[build-system\]' pyproject.toml; then
+            echo "buildable=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "buildable=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build
+        if: steps.buildable.outputs.buildable == 'true'
+        run: |
+          printf "[INFO] Building package...\n"
+          uv build
+
+      - name: Install Python for SBOM generation
+        if: hashFiles('pyproject.toml') != ''
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version-file: .python-version
+
+      - name: Sync environment for SBOM generation
+        if: hashFiles('pyproject.toml') != ''
+        run: |
+          export UV_EXTRA_INDEX_URL="${{ secrets.UV_EXTRA_INDEX_URL }}"
+          uv sync --all-extras --all-groups --frozen
+
+      - name: Generate SBOM (CycloneDX)
+        if: hashFiles('pyproject.toml') != ''
+        run: |
+          printf "[INFO] Generating SBOM in CycloneDX format...\n"
+          # Note: uvx caches the tool environment, so the second call is fast
+          uvx --from 'cyclonedx-bom>=7.0.0' cyclonedx-py environment --pyproject pyproject.toml --of JSON -o sbom.cdx.json
+          uvx --from 'cyclonedx-bom>=7.0.0' cyclonedx-py environment --pyproject pyproject.toml --of XML -o sbom.cdx.xml
+          printf "[INFO] SBOM generation complete\n"
+          printf "Generated files:\n"
+          ls -lh sbom.cdx.*
+
+      - name: Attest SBOM
+        # Attest only the JSON format as it's the canonical machine-readable format.
+        # The XML format is provided for compatibility but doesn't need separate attestation.
+        if: hashFiles('pyproject.toml') != '' && github.event.repository.private == false
+        uses: actions/attest@v4.1.0
+        with:
+          subject-path: sbom.cdx.json
+          sbom-path: sbom.cdx.json
+
+      - name: Upload SBOM artifacts
+        if: hashFiles('pyproject.toml') != ''
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: sbom
+          path: |
+            sbom.cdx.json
+            sbom.cdx.xml
+
+      - name: Generate SLSA provenance attestations
+        if: steps.buildable.outputs.buildable == 'true' && github.event.repository.private == false
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: dist/*
+
+      - name: Upload dist artifact
+        if: steps.buildable.outputs.buildable == 'true'
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: dist
+          path: dist
+
+  # Don't try to upload artifacts to GitHub Release at all
+  draft-release:
+    name: Draft GitHub Release
+    runs-on: ubuntu-latest
+    needs: [tag, build]
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7.6.0
+
+      - name: Generate release notes with git-cliff
+        run: uvx git-cliff --latest --output RELEASE_NOTES.md
+
+      - name: Download SBOM artifact
+        # Downloads sbom.cdx.json and sbom.cdx.xml into sbom/ directory
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: sbom
+          path: sbom
+        continue-on-error: true
+
+      - name: Create GitHub Release with artifacts
+        uses: ncipollo/release-action@v1.21.0
+        with:
+          tag: ${{ needs.tag.outputs.tag }}
+          name: ${{ needs.tag.outputs.tag }}
+          bodyFile: RELEASE_NOTES.md
+          draft: true
+          allowUpdates: true
+          artifacts: "sbom/*"
+
+  update-changelog:
+    name: Update CHANGELOG.md
+    runs-on: ubuntu-latest
+    needs: [tag, draft-release]
+    steps:
+      - name: Checkout Default Branch
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7.6.0
+
+      - name: Generate CHANGELOG.md with git-cliff
+        run: uvx git-cliff --output CHANGELOG.md
+
+      - name: Commit and push CHANGELOG.md
+        env:
+          TAG: ${{ needs.tag.outputs.tag }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git diff --staged --quiet || git commit -m "chore: update CHANGELOG.md for $TAG [skip ci]"
+          git push origin ${{ github.event.repository.default_branch }}
+
+  # Decide at step-level whether to publish
+  pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    environment: release
+    needs: [tag, build, draft-release]
+    outputs:
+      should_publish: ${{ steps.check_dist.outputs.should_publish }}
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Download dist artifact
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: dist
+          path: dist
+        # Continue if dist folder is not found. Don't fail the job.
+        continue-on-error: true
+
+      - name: Check if dist contains artifacts and not marked as private
+        id: check_dist
+        run: |
+          if [[ ! -d dist ]]; then
+            echo "::warning::No folder dist/. Skipping PyPI publish."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          else
+            if grep -R "Private :: Do Not Upload" pyproject.toml; then
+              echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+          cat "$GITHUB_OUTPUT"
+
+      # this should not take place, as "Private :: Do Not Upload" set in pyproject.toml
+      # repository-url and password only used for custom feeds, not for PyPI with OIDC
+      - name: Publish to PyPI
+        if: ${{ steps.check_dist.outputs.should_publish == 'true' }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          skip-existing: true
+          repository-url: ${{ vars.PYPI_REPOSITORY_URL }}
+          password: ${{ secrets.PYPI_TOKEN }}
+
+  devcontainer:
+    name: Publish Devcontainer Image
+    runs-on: ubuntu-latest
+    environment: release
+    needs: [tag, build, draft-release]
+    outputs:
+      should_publish: ${{ steps.check_publish.outputs.should_publish }}
+      image_name: ${{ steps.image_name.outputs.image_name }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Check if devcontainer should be published
+        id: check_publish
+        env:
+          PUBLISH_DEVCONTAINER: ${{ vars.PUBLISH_DEVCONTAINER }}
+        run: |
+          if [[ "$PUBLISH_DEVCONTAINER" == "true" ]] && [[ -d ".devcontainer" ]]; then
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            echo "🚀 Will build and publish devcontainer image"
+          else
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            echo "⏭️  Skipping devcontainer publish (PUBLISH_DEVCONTAINER not true or .devcontainer missing)"
+          fi
+
+      - name: Set registry
+        if: steps.check_publish.outputs.should_publish == 'true'
+        id: registry
+        run: |
+          REGISTRY="${{ vars.DEVCONTAINER_REGISTRY }}"
+          if [ -z "$REGISTRY" ]; then
+            REGISTRY="ghcr.io"
+          fi
+          echo "registry=$REGISTRY" >> "$GITHUB_OUTPUT"
+
+      - name: Login to Container Registry
+        if: steps.check_publish.outputs.should_publish == 'true'
+        uses: docker/login-action@v4.2.0
+        with:
+          registry: ${{ steps.registry.outputs.registry }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get lowercase repository owner
+        if: steps.check_publish.outputs.should_publish == 'true'
+        id: repo_owner
+        run: echo "owner_lc=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Get Image Name
+        if: steps.check_publish.outputs.should_publish == 'true'
+        id: image_name
+        run: |
+          # Check if custom name is provided, otherwise use default
+          if [ -z "${{ vars.DEVCONTAINER_IMAGE_NAME }}" ]; then
+            REPO_NAME_LC=$(echo "${{ github.event.repository.name }}" | tr '[:upper:]' '[:lower:]')
+            # Sanitize repo name: replace invalid characters with hyphens
+            # Docker image names must match [a-z0-9]+([._-][a-z0-9]+)*
+            # Replace leading dots and multiple consecutive separators
+            REPO_NAME_SANITIZED=$(echo "$REPO_NAME_LC" | sed 's/^[._-]*//; s/[._-][._-]*/-/g')
+            IMAGE_NAME="$REPO_NAME_SANITIZED/devcontainer"
+            echo "Using default image name component: $IMAGE_NAME"
+          else
+            IMAGE_NAME="${{ vars.DEVCONTAINER_IMAGE_NAME }}"
+            echo "Using custom image name component: $IMAGE_NAME"
+          fi
+
+          # Validate the image component matches [a-z0-9]+([._-][a-z0-9]+)* with optional / separators
+          if ! echo "$IMAGE_NAME" | grep -qE '^[a-z0-9]+([._-][a-z0-9]+)*(/[a-z0-9]+([._-][a-z0-9]+)*)*$'; then
+            echo "::error::Invalid image name component: $IMAGE_NAME"
+            echo "::error::Each component must match [a-z0-9]+([._-][a-z0-9]+)* separated by /"
+            exit 1
+          fi
+
+          IMAGE_NAME="${{ steps.registry.outputs.registry }}/${{ steps.repo_owner.outputs.owner_lc }}/$IMAGE_NAME"
+          echo "✅ Final image name: $IMAGE_NAME"
+          echo "image_name=$IMAGE_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Build and Publish Devcontainer Image
+        if: steps.check_publish.outputs.should_publish == 'true'
+        uses: devcontainers/ci@v0.3
+        with:
+          configFile: .devcontainer/devcontainer.json
+          push: always
+          imageName: ${{ steps.image_name.outputs.image_name }}
+          imageTag: ${{ needs.tag.outputs.tag }}
+
+  finalise-release:
+    name: Finalise Release
+    runs-on: ubuntu-latest
+    needs: [tag, pypi, devcontainer]
+    if: needs.pypi.result == 'success' || needs.devcontainer.result == 'success'
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7.6.0
+        with:
+          version: "0.11.16"
+
+      - name: "Sync the virtual environment for ${{ github.repository }}"
+        shell: bash
+        run: |
+          export UV_EXTRA_INDEX_URL="${{ secrets.uv_extra_index_url }}"
+          # will just use .python-version?
+          uv sync --all-extras --all-groups --frozen
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+
+      - name: Generate Devcontainer Link
+        id: devcontainer_link
+        if: needs.devcontainer.outputs.should_publish == 'true' && needs.devcontainer.result == 'success'
+        run: |
+          FULL_IMAGE="${{ needs.devcontainer.outputs.image_name }}:${{ needs.tag.outputs.tag }}"
+          {
+            echo "message<<EOF"
+            echo "### Devcontainer Image"
+            echo ""
+            echo "\`$FULL_IMAGE\`"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Generate PyPI Link
+        id: pypi_link
+        if: needs.pypi.outputs.should_publish == 'true' && needs.pypi.result == 'success'
+        run: |
+          PACKAGE_NAME=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['name'])")
+          VERSION="${{ needs.tag.outputs.tag }}"
+          VERSION=${VERSION#v}
+
+          REPO_URL="${{ vars.PYPI_REPOSITORY_URL || '' }}"
+          if [ -z "$REPO_URL" ]; then
+             LINK="https://pypi.org/project/$PACKAGE_NAME/$VERSION/"
+             NAME="PyPI Package"
+          else
+             LINK="$REPO_URL"
+             NAME="Custom Feed Package"
+          fi
+
+          {
+            echo "message<<EOF"
+            echo "### $NAME"
+            echo ""
+            echo "[$PACKAGE_NAME]($LINK)"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Publish Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.tag.outputs.tag }}
+          DEVCONTAINER_MSG: ${{ steps.devcontainer_link.outputs.message }}
+          PYPI_MSG: ${{ steps.pypi_link.outputs.message }}
+        run: |
+          # Get existing auto-generated release notes (gracefully handle missing release)
+          EXISTING=$(gh release view "$TAG" --json body --jq '.body // ""' 2>/dev/null || echo "")
+
+          # Append links to release body
+          {
+            printf '%s' "$EXISTING"
+            [ -n "$DEVCONTAINER_MSG" ] && printf '\n\n%s' "$DEVCONTAINER_MSG"
+            [ -n "$PYPI_MSG" ] && printf '\n\n%s' "$PYPI_MSG"
+          } > /tmp/notes.md
+
+          gh release edit "$TAG" --draft=false --notes-file /tmp/notes.md
+
 

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,7 +1,7 @@
-sha: 86f6542c8fef07f688e79d7c4fe46cdf22cbecf9
+sha: b46e11380e4073802302c551ab666ba9dec1cd88
 repo: jebel-quant/rhiza
 host: github
-ref: v0.16.0
+ref: v0.17.0
 include: []
 exclude: []
 templates:
@@ -107,5 +107,5 @@ files:
 - ruff.toml
 profiles:
 - github-project
-synced_at: '2026-05-27T09:53:06Z'
+synced_at: '2026-05-27T11:01:16Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 template-repository: "jebel-quant/rhiza"
-template-branch: "v0.16.0"
+template-branch: "v0.17.0"
 
 profiles:
   - github-project


### PR DESCRIPTION
## Summary

Bumps the Rhiza template to `v0.17.0`, syncs the generated template changes, and resolves merge conflicts by merging `origin/main` into the PR branch so the branch is up to date and mergeable.

## Changes

- Bumped `template-branch` to `v0.17.0` in `.rhiza/template.yml`
- Bumped `.rhiza/.rhiza-version` and ran `make sync` to apply upstream template updates
- Merged `origin/main` into this branch and resolved conflicts in `.github/workflows/rhiza_release.yml` while preserving the intended release workflow behavior

## Testing

- [ ] `make test` passes locally
- [ ] `make fmt` has been run
- [ ] New tests added (or explain why not needed)

Attempted local checks, but environment/network limitations prevented installing required tooling (`uv/uvx`) and running the project test/lint targets.

## Checklist

- [x] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated if behaviour changed
- [ ] `make deptry` passes (no unused or missing dependencies)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to support manual invocation with explicit version tags, while preserving existing tag-based trigger automation. Added support for optional secret passthrough in manual invocations.
  * Updated template configuration dependency to version 0.17.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tschm/pyhrp/pull/690?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->