### PR TITLE
refactor: harden API, validate inputs, speed up allocation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,6 +76,13 @@ repos:
         args: [--config=pyproject.toml]
         files: ^src/
 
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v2.1.0
+    hooks:
+      - id: mypy
+        files: ^src/
+        additional_dependencies: [numpy, polars]
+
   - repo: https://github.com/Jebel-Quant/rhiza-hooks
     rev: v0.4.0  # Use the latest release
     hooks:

--- a/README.md
+++ b/README.md
@@ -46,12 +46,16 @@ Here's a simple example
 
 ```python
 import polars as pl
-from pyhrp.hrp import build_tree, compute_cov, compute_corr
-from pyhrp.algos import risk_parity
+from pyhrp import build_tree, compute_cov, compute_corr, risk_parity
 
 prices = pl.read_csv("tests/resources/stock_prices.csv", try_parse_dates=True).drop("date")
 
-returns = prices.select(pl.all().pct_change()).drop_nulls().fill_null(0.0)
+returns = (
+    prices.select(pl.all().pct_change())
+    .filter(pl.any_horizontal(pl.all().is_not_null()))
+    .fill_null(0.0)
+    .fill_nan(0.0)
+)
 cov = compute_cov(returns)
 cor = compute_corr(returns)
 
@@ -69,7 +73,7 @@ For your convenience you can bypass the construction of the covariance and
 correlation matrix, and the construction of the dendrogram.
 
 ```python
-from pyhrp.hrp import hrp
+from pyhrp import hrp
 root = hrp(prices=prices, method="ward", bisection=False)
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 [project.urls]
@@ -40,6 +41,7 @@ test = [
     "pytest-timeout>=2.0",
 ]
 lint = [
+    "mypy>=1.14",
     "pre-commit>=4.0",
 ]
 
@@ -52,6 +54,14 @@ packages = ["src/pyhrp"]
 
 [tool.coverage.report]
 fail_under = 90
+
+[tool.mypy]
+files = ["src"]
+strict = true
+
+[[tool.mypy.overrides]]
+module = ["scipy.*", "plotly.*"]
+ignore_missing_imports = true
 
 [tool.deptry]
 package_module_name_map = {numpy = "numpy", scipy = "scipy", marimo = "marimo", polars = "polars", plotly = "plotly"}

--- a/ruff.toml
+++ b/ruff.toml
@@ -4,7 +4,7 @@
 # Maximum line length for the entire project
 line-length = 120
 # Target Python version
-target-version = "py311"
+target-version = "py312"
 
 # Exclude directories with Jinja template variables in their names
 exclude = ["**/[{][{]*/", "**/*[}][}]*/"]

--- a/src/pyhrp/__init__.py
+++ b/src/pyhrp/__init__.py
@@ -1,9 +1,29 @@
 """Hierarchical Risk Parity (HRP) portfolio optimization library.
 
 This package implements the Hierarchical Risk Parity algorithm for portfolio
-optimization, as introduced by Marcos Lopez de Prado.
+optimization, as introduced by Marcos Lopez de Prado, and the Schur
+Complementary Allocation extension by Peter Cotton.
 """
 
 import importlib.metadata
 
+from .algos import one_over_n, risk_parity, schur_risk_parity
+from .cluster import Cluster, Portfolio
+from .hrp import Dendrogram, build_tree, compute_corr, compute_cov, hrp, schur_hrp
+
 __version__ = importlib.metadata.version("pyhrp")
+
+__all__ = [
+    "Cluster",
+    "Dendrogram",
+    "Portfolio",
+    "__version__",
+    "build_tree",
+    "compute_corr",
+    "compute_cov",
+    "hrp",
+    "one_over_n",
+    "risk_parity",
+    "schur_hrp",
+    "schur_risk_parity",
+]

--- a/src/pyhrp/algos.py
+++ b/src/pyhrp/algos.py
@@ -2,12 +2,13 @@
 
 This module implements various portfolio optimization algorithms:
 - risk_parity: The main hierarchical risk parity algorithm
+- schur_risk_parity: Schur Complementary Allocation (Cotton, arXiv:2411.05807)
 - one_over_n: A simple equal-weight allocation strategy
 """
 
 from __future__ import annotations
 
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from copy import deepcopy
 from typing import TYPE_CHECKING
 
@@ -29,6 +30,11 @@ def risk_parity(root: Cluster, cov: pl.DataFrame) -> Cluster:
     traverses the cluster tree and assigns weights to each node based on
     the risk parity principle.
 
+    Note:
+        The tree is modified in place: the portfolio of every node is rebuilt
+        from scratch, so the function is idempotent and a tree can be reused
+        with a different covariance matrix.
+
     Args:
         root (Cluster): The root node of the cluster tree
         cov (pl.DataFrame): Covariance matrix of asset returns
@@ -46,63 +52,17 @@ def risk_parity(root: Cluster, cov: pl.DataFrame) -> Cluster:
         >>> round(cluster.portfolio["B"], 1)
         0.8
     """
-    if root.is_leaf:
-        # a node is a leaf if has no further relatives downstream.
-        asset = cov.columns[int(root.value)]
-        root.portfolio[asset] = 1.0
-        return root
+    cov_np = cov.to_numpy()
+    index = {name: i for i, name in enumerate(cov.columns)}
 
-    # drill down on the left
-    if not isinstance(root.left, Cluster):
-        raise TypeError("Expected left child to be a Cluster")  # noqa: TRY003
-    if not isinstance(root.right, Cluster):
-        raise TypeError("Expected right child to be a Cluster")  # noqa: TRY003
-    root.left = risk_parity(root.left, cov)
-    # drill down on the right
-    root.right = risk_parity(root.right, cov)
+    def combine(cluster: Cluster) -> Cluster:
+        """Combine the child portfolios of a cluster via inverse-variance split."""
+        left, right = _children(cluster)
+        v_left = _block_variance(left.portfolio, cov_np, index)
+        v_right = _block_variance(right.portfolio, cov_np, index)
+        return _split(cluster, v_left, v_right)
 
-    # combine left and right into a new cluster
-    return _parity(root, cov=cov)
-
-
-def _parity(cluster: Cluster, cov: pl.DataFrame) -> Cluster:
-    """Compute risk parity weights for a parent cluster from its children.
-
-    This function implements the core risk parity principle: allocating weights
-    inversely proportional to risk, so that each sub-portfolio contributes
-    equally to the total portfolio risk.
-
-    Args:
-        cluster (Cluster): The parent cluster with left and right children
-        cov (pl.DataFrame): Covariance matrix of asset returns
-
-    Returns:
-        Cluster: The parent cluster with portfolio weights assigned
-    """
-    # Calculate variances of left and right sub-portfolios
-    if not isinstance(cluster.left, Cluster):
-        raise TypeError("Expected left child to be a Cluster")  # noqa: TRY003
-    if not isinstance(cluster.right, Cluster):
-        raise TypeError("Expected right child to be a Cluster")  # noqa: TRY003
-    v_left = cluster.left.portfolio.variance(cov)
-    v_right = cluster.right.portfolio.variance(cov)
-
-    # Calculate weights inversely proportional to risk
-    # such that v_left * alpha_left == v_right * alpha_right and alpha_left + alpha_right = 1
-    alpha_left = v_right / (v_left + v_right)
-    alpha_right = v_left / (v_left + v_right)
-
-    # Combine assets from left and right clusters with their adjusted weights
-    assets = {
-        **{k: alpha_left * v for k, v in cluster.left.portfolio.weights.items()},
-        **{k: alpha_right * v for k, v in cluster.right.portfolio.weights.items()},
-    }
-
-    # Assign the combined weights to the parent cluster's portfolio
-    for asset, weight in assets.items():
-        cluster.portfolio[asset] = weight
-
-    return cluster
+    return _allocate(root, cov.columns, combine)
 
 
 def schur_risk_parity(root: Cluster, cov: pl.DataFrame, gamma: float = 0.5) -> Cluster:
@@ -113,6 +73,11 @@ def schur_risk_parity(root: Cluster, cov: pl.DataFrame, gamma: float = 0.5) -> C
     At gamma=0 this recovers standard HRP; at gamma=1 it recovers the minimum-variance
     portfolio through the same recursive structure.
 
+    Note:
+        The tree is modified in place: the portfolio of every node is rebuilt
+        from scratch, so the function is idempotent and a tree can be reused
+        with a different covariance matrix or gamma.
+
     Args:
         root (Cluster): The root node of the cluster tree
         cov (pl.DataFrame): Covariance matrix of asset returns
@@ -120,6 +85,9 @@ def schur_risk_parity(root: Cluster, cov: pl.DataFrame, gamma: float = 0.5) -> C
 
     Returns:
         Cluster: The root node with portfolio weights assigned
+
+    Raises:
+        ValueError: If gamma is outside the interval [0, 1].
 
     Examples:
         >>> import polars as pl
@@ -131,65 +99,120 @@ def schur_risk_parity(root: Cluster, cov: pl.DataFrame, gamma: float = 0.5) -> C
         >>> round(cluster.portfolio["B"], 1)
         0.8
     """
+    if not 0.0 <= gamma <= 1.0:
+        msg = f"gamma must be in [0, 1], got {gamma}"
+        raise ValueError(msg)
+
+    cov_np = cov.to_numpy()
+    index = {name: i for i, name in enumerate(cov.columns)}
+
+    def combine(cluster: Cluster) -> Cluster:
+        """Combine the child portfolios of a cluster via a Schur-augmented split."""
+        left, right = _children(cluster)
+
+        li = [index[a] for a in left.portfolio.assets]
+        ri = [index[a] for a in right.portfolio.assets]
+
+        a_mat = cov_np[np.ix_(li, li)]
+        b_mat = cov_np[np.ix_(li, ri)]
+        d_mat = cov_np[np.ix_(ri, ri)]
+
+        w_left = np.array([left.portfolio[a] for a in left.portfolio.assets])
+        w_right = np.array([right.portfolio[a] for a in right.portfolio.assets])
+
+        # Schur-augmented blocks: condition each group on the other
+        a_aug = a_mat - gamma * (b_mat @ _solve(d_mat, b_mat.T))
+        d_aug = d_mat - gamma * (b_mat.T @ _solve(a_mat, b_mat))
+
+        v_left = float(w_left @ a_aug @ w_left)
+        v_right = float(w_right @ d_aug @ w_right)
+        return _split(cluster, v_left, v_right)
+
+    return _allocate(root, cov.columns, combine)
+
+
+def _allocate(root: Cluster, assets: list[str], combine: Callable[[Cluster], Cluster]) -> Cluster:
+    """Traverse the tree bottom-up, assigning leaf portfolios and combining children.
+
+    Every node's portfolio is replaced, never accumulated into, which keeps
+    repeated allocations on the same tree idempotent.
+
+    Args:
+        root (Cluster): The (sub)tree to allocate weights for
+        assets (list[str]): Asset names; a leaf's value indexes into this list
+        combine (Callable[[Cluster], Cluster]): Combines the two child portfolios
+            of a node into the node's own portfolio
+
+    Returns:
+        Cluster: The input node with portfolio weights assigned
+    """
     if root.is_leaf:
-        asset = cov.columns[int(root.value)]
-        root.portfolio[asset] = 1.0
+        root.portfolio = Portfolio()
+        root.portfolio[assets[int(root.value)]] = 1.0
         return root
 
-    if not isinstance(root.left, Cluster):
-        raise TypeError("Expected left child to be a Cluster")  # noqa: TRY003
-    if not isinstance(root.right, Cluster):
-        raise TypeError("Expected right child to be a Cluster")  # noqa: TRY003
-    root.left = schur_risk_parity(root.left, cov, gamma)
-    root.right = schur_risk_parity(root.right, cov, gamma)
-
-    return _schur_parity(root, cov=cov, gamma=gamma)
+    left, right = _children(root)
+    root.left = _allocate(left, assets, combine)
+    root.right = _allocate(right, assets, combine)
+    return combine(root)
 
 
-def _schur_parity(cluster: Cluster, cov: pl.DataFrame, gamma: float) -> Cluster:
-    """Compute Schur-augmented risk parity weights for a parent cluster.
-
-    Replaces sub-covariance blocks a_mat and d_mat with Schur complements
-    a_aug = a_mat - gamma * b_mat @ inv(d_mat) @ b_mat.T and
-    d_aug = d_mat - gamma * b_mat.T @ inv(a_mat) @ b_mat before splitting risk.
-    This incorporates cross-group covariance information that standard HRP discards.
-    """
+def _children(cluster: Cluster) -> tuple[Cluster, Cluster]:
+    """Return the validated left and right children of a non-leaf cluster."""
     if not isinstance(cluster.left, Cluster):
         raise TypeError("Expected left child to be a Cluster")  # noqa: TRY003
     if not isinstance(cluster.right, Cluster):
         raise TypeError("Expected right child to be a Cluster")  # noqa: TRY003
+    return cluster.left, cluster.right
 
-    left_assets = cluster.left.portfolio.assets
-    right_assets = cluster.right.portfolio.assets
 
-    cov_np = cov.to_numpy()
-    cols = cov.columns
-    li = [cols.index(a) for a in left_assets]
-    ri = [cols.index(a) for a in right_assets]
+def _block_variance(portfolio: Portfolio, cov_np: np.ndarray, index: dict[str, int]) -> float:
+    """Compute the variance of a portfolio against a precomputed covariance array."""
+    assets = portfolio.assets
+    idx = [index[a] for a in assets]
+    w = np.array([portfolio[a] for a in assets])
+    return float(w @ cov_np[np.ix_(idx, idx)] @ w)
 
-    a_mat = cov_np[np.ix_(li, li)]
-    b_mat = cov_np[np.ix_(li, ri)]
-    d_mat = cov_np[np.ix_(ri, ri)]
 
-    w_left = np.array([cluster.left.portfolio[a] for a in left_assets])
-    w_right = np.array([cluster.right.portfolio[a] for a in right_assets])
+def _split(cluster: Cluster, v_left: float, v_right: float) -> Cluster:
+    """Distribute weight between the two children inversely proportional to risk.
 
-    # Schur-augmented blocks: condition each group on the other
-    a_aug = a_mat - gamma * (b_mat @ np.linalg.solve(d_mat, b_mat.T))
-    d_aug = d_mat - gamma * (b_mat.T @ np.linalg.solve(a_mat, b_mat))
+    The split satisfies v_left * alpha_left == v_right * alpha_right with
+    alpha_left + alpha_right == 1. If both variances are zero (e.g. riskless
+    sub-portfolios), the weight is split equally.
 
-    v_left = float(w_left @ a_aug @ w_left)
-    v_right = float(w_right @ d_aug @ w_right)
+    Args:
+        cluster (Cluster): The parent cluster with left and right children
+        v_left (float): Variance of the left sub-portfolio
+        v_right (float): Variance of the right sub-portfolio
 
-    alpha_left = v_right / (v_left + v_right)
+    Returns:
+        Cluster: The parent cluster with portfolio weights assigned
+    """
+    left, right = _children(cluster)
+    total = v_left + v_right
+    alpha_left = v_right / total if total > 0 else 0.5
     alpha_right = 1.0 - alpha_left
 
-    for asset, weight in cluster.left.portfolio.weights.items():
+    cluster.portfolio = Portfolio()
+    for asset, weight in left.portfolio.weights.items():
         cluster.portfolio[asset] = alpha_left * weight
-    for asset, weight in cluster.right.portfolio.weights.items():
+    for asset, weight in right.portfolio.weights.items():
         cluster.portfolio[asset] = alpha_right * weight
 
     return cluster
+
+
+def _solve(m: np.ndarray, b: np.ndarray) -> np.ndarray:
+    """Solve m @ x = b, falling back to least squares for singular matrices.
+
+    Covariance blocks of collinear assets are singular; the minimum-norm
+    least-squares solution keeps the Schur augmentation well-defined there.
+    """
+    try:
+        return np.linalg.solve(m, b)
+    except np.linalg.LinAlgError:
+        return np.asarray(np.linalg.lstsq(m, b, rcond=None)[0])
 
 
 def one_over_n(dendrogram: Dendrogram) -> Generator[tuple[int, Portfolio]]:

--- a/src/pyhrp/cluster.py
+++ b/src/pyhrp/cluster.py
@@ -52,7 +52,8 @@ class Portfolio:
             float: Portfolio variance
         """
         assets = self.assets
-        row_indices = [cov.columns.index(a) for a in assets]
+        index = {name: i for i, name in enumerate(cov.columns)}
+        row_indices = [index[a] for a in assets]
         cov_matrix = cov.to_numpy()
         c = cov_matrix[np.ix_(row_indices, row_indices)]
         w = np.array([self._weights[a] for a in assets])
@@ -128,22 +129,11 @@ class Cluster(Node[int]):
         super().__init__(value=value, left=left, right=right)
         self.portfolio = Portfolio()
 
-    @property
-    def is_leaf(self) -> bool:
-        """Check if this cluster is a leaf node (has no children).
-
-        Returns:
-            bool: True if this is a leaf node, False otherwise
-        """
-        return self.left is None and self.right is None
-
-    # Preserve left-to-right dendrogram order required by HRP (not default post-order traversal).
+    # Override narrows the return type to list[Cluster] and validates tree integrity;
+    # the traversal order (left to right) matches Node.leaves.
     @property
     def leaves(self) -> list[Cluster]:
-        """Get all reachable leaf nodes in the correct order.
-
-        Note that the leaves method of the Node class implemented in BinaryTree
-        is not respecting the 'correct' order of the nodes.
+        """Get all reachable leaf nodes in left-to-right dendrogram order.
 
         Returns:
             list[Cluster]: List of all leaf nodes reachable from this cluster

--- a/src/pyhrp/hrp.py
+++ b/src/pyhrp/hrp.py
@@ -28,15 +28,29 @@ __all__ = ["Dendrogram", "build_tree", "compute_corr", "compute_cov", "hrp", "sc
 def compute_cov(df: pl.DataFrame) -> pl.DataFrame:
     """Compute covariance matrix from a DataFrame of returns."""
     cols = df.columns
-    cov = np.cov(df.to_numpy().T)
-    return pl.DataFrame(dict(zip(cols, cov, strict=False)))
+    cov = np.atleast_2d(np.cov(df.to_numpy().T))
+    return pl.DataFrame(dict(zip(cols, cov, strict=True)))
 
 
 def compute_corr(df: pl.DataFrame) -> pl.DataFrame:
     """Compute correlation matrix from a DataFrame of returns."""
     cols = df.columns
-    corr = np.corrcoef(df.to_numpy().T)
-    return pl.DataFrame(dict(zip(cols, corr, strict=False)))
+    corr = np.atleast_2d(np.corrcoef(df.to_numpy().T))
+    return pl.DataFrame(dict(zip(cols, corr, strict=True)))
+
+
+def _returns(prices: pl.DataFrame) -> pl.DataFrame:
+    """Compute simple returns from prices.
+
+    Drops leading all-null rows produced by pct_change and fills remaining
+    nulls/NaNs (e.g. from missing prices) with zero returns.
+    """
+    return (
+        prices.select(pl.all().pct_change())
+        .filter(pl.any_horizontal(pl.all().is_not_null()))
+        .fill_null(0.0)
+        .fill_nan(0.0)
+    )
 
 
 def hrp(
@@ -72,12 +86,7 @@ def hrp(
         >>> round(sum(root.portfolio.weights.values()), 6)
         1.0
     """
-    returns = (
-        prices.select(pl.all().pct_change())
-        .filter(pl.any_horizontal(pl.all().is_not_null()))
-        .fill_null(0.0)
-        .fill_nan(0.0)
-    )
+    returns = _returns(prices)
     cov = compute_cov(returns)
     cor = compute_corr(returns)
     node = node or build_tree(cor, method=method, bisection=bisection).root
@@ -119,12 +128,7 @@ def schur_hrp(
         >>> round(sum(root.portfolio.weights.values()), 6)
         1.0
     """
-    returns = (
-        prices.select(pl.all().pct_change())
-        .filter(pl.any_horizontal(pl.all().is_not_null()))
-        .fill_null(0.0)
-        .fill_nan(0.0)
-    )
+    returns = _returns(prices)
     cov = compute_cov(returns)
     cor = compute_corr(returns)
     node = node or build_tree(cor, method=method, bisection=bisection).root
@@ -172,6 +176,9 @@ class Dendrogram:
 
     def plot(self, **kwargs: object) -> go.Figure:
         """Build and return a plotly dendrogram figure."""
+        if self.linkage is None:
+            msg = "Dendrogram has no linkage matrix to plot."
+            raise ValueError(msg)
         ddata = sch.dendrogram(self.linkage, labels=self.assets, no_plot=True, **kwargs)
         fig = go.Figure()
         for xs, ys in zip(ddata["icoord"], ddata["dcoord"], strict=False):
@@ -204,7 +211,7 @@ def _compute_distance_matrix(corr: pl.DataFrame) -> pl.DataFrame:
     dist = np.sqrt(np.clip((1.0 - c) / 2.0, a_min=0.0, a_max=1.0))
     np.fill_diagonal(dist, 0.0)
     cols = corr.columns
-    return pl.DataFrame(dict(zip(cols, dist, strict=False)))
+    return pl.DataFrame(dict(zip(cols, dist, strict=True)))
 
 
 def _bisect_tree(ids: list[int], next_id: int) -> tuple[Cluster, int]:
@@ -279,6 +286,20 @@ def build_tree(
     """
     if not isinstance(cor, pl.DataFrame):
         raise TypeError("Correlation matrix must be a polars DataFrame.")  # noqa: TRY003
+    if len(cor.columns) < 2:
+        msg = "Correlation matrix must contain at least two assets."
+        raise ValueError(msg)
+    c = cor.to_numpy()
+    bad = [col for col, diag in zip(cor.columns, np.diagonal(c), strict=True) if not np.isfinite(diag)]
+    if bad:
+        msg = (
+            f"Correlation matrix contains non-finite values for assets {bad}; "
+            "constant (zero-variance) price series produce NaN correlations."
+        )
+        raise ValueError(msg)
+    if not np.isfinite(c).all():
+        msg = "Correlation matrix contains non-finite values."
+        raise ValueError(msg)
     dist = _compute_distance_matrix(cor)
     links = sch.linkage(ssd.squareform(dist.to_numpy(), checks=False), method=method)
 

--- a/src/pyhrp/treelib.py
+++ b/src/pyhrp/treelib.py
@@ -8,17 +8,14 @@ from __future__ import annotations
 
 from collections import deque
 from collections.abc import Iterator, Sequence
-from typing import Generic, TypeVar
 
 # Type for node values
 NodeValue = int | float | str
 
-T = TypeVar("T", bound=NodeValue)
-
 __all__ = ["Node"]
 
 
-class Node(Generic[T]):
+class Node[T: NodeValue]:
     """A binary tree node with left and right children.
 
     This class implements the minimal functionality needed from the binarytree.Node class

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -6,7 +6,7 @@ import numpy as np
 import polars as pl
 import pytest
 
-from pyhrp.algos import _parity, risk_parity
+from pyhrp.algos import risk_parity
 from pyhrp.cluster import Cluster
 from pyhrp.treelib import Node
 
@@ -67,26 +67,6 @@ def test_risk_parity_non_cluster_right() -> None:
     cov = pl.DataFrame({"A": [1.0]})
     with pytest.raises(TypeError, match="Expected right child to be a Cluster"):
         risk_parity(root, cov)
-
-
-def test_parity_non_cluster_left() -> None:
-    """TypeError is raised when _parity encounters a non-Cluster left child."""
-    cluster = Cluster(value=10)
-    cluster.left = Node(1)
-    cluster.right = Cluster(value=2)
-    cov = pl.DataFrame({"A": [1.0]})
-    with pytest.raises(TypeError, match="Expected left child to be a Cluster"):
-        _parity(cluster, cov)
-
-
-def test_parity_non_cluster_right() -> None:
-    """TypeError is raised when _parity encounters a non-Cluster right child."""
-    cluster = Cluster(value=10)
-    cluster.left = Cluster(value=1)
-    cluster.right = Node(2)
-    cov = pl.DataFrame({"A": [1.0]})
-    with pytest.raises(TypeError, match="Expected right child to be a Cluster"):
-        _parity(cluster, cov)
 
 
 def test_leaves_only_right_child() -> None:

--- a/tests/test_schur.py
+++ b/tests/test_schur.py
@@ -6,7 +6,7 @@ import polars as pl
 import pytest
 from polars import DataFrame
 
-from pyhrp.algos import _schur_parity, risk_parity, schur_risk_parity
+from pyhrp.algos import risk_parity, schur_risk_parity
 from pyhrp.cluster import Cluster
 from pyhrp.hrp import build_tree, compute_corr, compute_cov, hrp, schur_hrp
 from pyhrp.treelib import Node
@@ -129,24 +129,3 @@ def test_schur_risk_parity_raises_for_non_cluster_right() -> None:
     root.right = Node(1)  # type: ignore[assignment]
     with pytest.raises(TypeError, match="Expected right child to be a Cluster"):
         schur_risk_parity(root=root, cov=cov, gamma=0.5)
-
-
-def test_schur_parity_raises_for_non_cluster_left() -> None:
-    """_schur_parity raises TypeError when left child is not a Cluster."""
-    cov = pl.DataFrame({"A": [4.0, 0.0], "B": [0.0, 1.0]})
-    cluster = Cluster(2)
-    cluster.left = Node(0)  # type: ignore[assignment]
-    cluster.right = Cluster(1)
-    with pytest.raises(TypeError, match="Expected left child to be a Cluster"):
-        _schur_parity(cluster=cluster, cov=cov, gamma=0.5)
-
-
-def test_schur_parity_raises_for_non_cluster_right() -> None:
-    """_schur_parity raises TypeError when right child is not a Cluster."""
-    cov = pl.DataFrame({"A": [4.0, 0.0], "B": [0.0, 1.0]})
-    left = Cluster(0)
-    cluster = Cluster(2)
-    cluster.left = left
-    cluster.right = Node(1)  # type: ignore[assignment]
-    with pytest.raises(TypeError, match="Expected right child to be a Cluster"):
-        _schur_parity(cluster=cluster, cov=cov, gamma=0.5)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,104 @@
+"""Tests for input validation and edge-case handling."""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import pytest
+
+import pyhrp
+from pyhrp import build_tree, compute_corr, compute_cov, hrp, risk_parity, schur_hrp, schur_risk_parity
+from pyhrp.cluster import Cluster
+
+
+def test_top_level_exports() -> None:
+    """The public API is importable directly from the pyhrp package."""
+    for name in pyhrp.__all__:
+        assert getattr(pyhrp, name) is not None
+
+
+@pytest.mark.parametrize("gamma", [-0.1, 1.5, 5.0])
+def test_gamma_out_of_range_raises(gamma: float) -> None:
+    """schur_risk_parity rejects gamma outside [0, 1]."""
+    cov = pl.DataFrame({"A": [4.0, 0.0], "B": [0.0, 1.0]})
+    root = Cluster(2, left=Cluster(0), right=Cluster(1))
+    with pytest.raises(ValueError, match="gamma must be in"):
+        schur_risk_parity(root=root, cov=cov, gamma=gamma)
+
+
+@pytest.mark.parametrize("gamma", [0.0, 0.5, 1.0])
+def test_gamma_boundaries_accepted(gamma: float) -> None:
+    """schur_risk_parity accepts the boundary values 0 and 1."""
+    cov = pl.DataFrame({"A": [4.0, 0.0], "B": [0.0, 1.0]})
+    root = Cluster(2, left=Cluster(0), right=Cluster(1))
+    cluster = schur_risk_parity(root=root, cov=cov, gamma=gamma)
+    assert sum(cluster.portfolio.weights.values()) == pytest.approx(1.0)
+
+
+def test_zero_variance_asset_raises_with_name() -> None:
+    """A constant price series produces a clear error naming the asset."""
+    prices = pl.DataFrame(
+        {
+            "A": [100.0, 101.0, 99.0, 102.0, 103.0],
+            "B": [50.0, 50.0, 50.0, 50.0, 50.0],
+        }
+    )
+    with (
+        pytest.warns(RuntimeWarning),
+        pytest.raises(ValueError, match=r"non-finite values for assets \['B'\]"),
+    ):
+        hrp(prices)
+
+
+def test_compute_cov_single_asset() -> None:
+    """Covariance of a single asset is a 1x1 matrix, not an obscure TypeError."""
+    df = pl.DataFrame({"A": [1.0, 2.0, 3.0]})
+    cov = compute_cov(df)
+    assert cov.shape == (1, 1)
+    assert cov["A"][0] == pytest.approx(1.0)
+
+
+def test_compute_corr_single_asset() -> None:
+    """Correlation of a single asset is a 1x1 matrix."""
+    df = pl.DataFrame({"A": [1.0, 2.0, 3.0]})
+    corr = compute_corr(df)
+    assert corr.shape == (1, 1)
+    assert corr["A"][0] == pytest.approx(1.0)
+
+
+def test_build_tree_requires_two_assets() -> None:
+    """build_tree rejects correlation matrices with fewer than two assets."""
+    cor = pl.DataFrame({"A": [1.0]})
+    with pytest.raises(ValueError, match="at least two assets"):
+        build_tree(cor)
+
+
+def test_risk_parity_idempotent() -> None:
+    """Repeated allocation on the same tree yields identical weights."""
+    cov = pl.DataFrame({"A": [4.0, 0.0], "B": [0.0, 1.0]})
+    root = Cluster(2, left=Cluster(0), right=Cluster(1))
+    first = dict(risk_parity(root=root, cov=cov).portfolio.weights)
+    second = dict(risk_parity(root=root, cov=cov).portfolio.weights)
+    assert first == second
+
+
+def test_risk_parity_zero_variance_split() -> None:
+    """Two riskless children split the weight equally instead of producing NaNs."""
+    cov = pl.DataFrame({"A": [0.0, 0.0], "B": [0.0, 0.0]})
+    root = Cluster(2, left=Cluster(0), right=Cluster(1))
+    weights = risk_parity(root=root, cov=cov).portfolio.weights
+    assert weights == {"A": 0.5, "B": 0.5}
+
+
+def test_schur_singular_block_does_not_crash() -> None:
+    """Collinear assets (singular covariance block) fall back to least squares."""
+    rng = np.random.default_rng(42)
+    a = 100.0 + np.cumsum(rng.normal(0.0, 1.0, 50))
+    c = 50.0 + np.cumsum(rng.normal(0.0, 1.0, 50))
+    d = 20.0 + np.cumsum(rng.normal(0.0, 1.0, 50))
+    prices = pl.DataFrame({"A": a, "B": 2.0 * a, "C": c, "D": d})
+
+    cluster = schur_hrp(prices, gamma=1.0)
+    weights = cluster.portfolio.weights
+    assert all(np.isfinite(w) for w in weights.values())
+    assert sum(weights.values()) == pytest.approx(1.0)

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version < '3.15'",
+]
 
 [[package]]
 name = "anyio"
@@ -13,6 +17,46 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "ast-serialize"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/9d/09e27731bd5864a9ce04e3244074e674bb8936bf62b45e0357248717adac/ast_serialize-0.5.0.tar.gz", hash = "sha256:5880091bfe6f4f986f22866375c2e884843e7a0b6343ae41aeea659613d879b6", size = 61157, upload-time = "2026-05-17T17:48:29.429Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/9a/13dde51ba9e15f8b97957ab7cb0120d0e381524d651c6bd630b9c359227f/ast_serialize-0.5.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8f5c14f169eb0972c0c21bada5358b23d6047c76583b005234f865b11f1fa00a", size = 1183520, upload-time = "2026-05-17T17:47:30.831Z" },
+    { url = "https://files.pythonhosted.org/packages/37/de/5a7f0a9fe68944f536632a5af84676739c7d2582be42deb082634bf3a754/ast_serialize-0.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7d1a2de9de5be04652f0ed60738356ef94f66db37924a9499fffe98dc491aa0b", size = 1175779, upload-time = "2026-05-17T17:47:32.551Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/81/0bb853e76e4f6e9a1855d569003c59e19ffac45f7079d91505d1bb212f92/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:be5173fb66f9b49026d9d5a2ff0fc7c7009077107c0eb285b2d60fdf1fe10bd1", size = 1233750, upload-time = "2026-05-17T17:47:34.731Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/d3/4cf705beeccc08754d0bbda99aefff26110e209b9a07ac8a6b60eec48531/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f8015cd071ac1339924ee2b8098c93e00e155f30a16f40ec9816fcf84f4753f6", size = 1235942, upload-time = "2026-05-17T17:47:36.287Z" },
+    { url = "https://files.pythonhosted.org/packages/26/c8/ee097e437ea27dd2b8b227865c875492b585650a5802a22d82b304c8201b/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5499e8797edff2a9186aa313ed382c6b422e798e9332d9953badcee6e69a88f2", size = 1442517, upload-time = "2026-05-17T17:47:38.17Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/bd/68063442838f1ba68ec72b5436430bc75b3bb17a1a3c3063f09b0c05ae2b/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6848f2a093fb5548751a9a09bff8fcd229e2bbeb0e3331f391b6ae6d26cd9903", size = 1254081, upload-time = "2026-05-17T17:47:39.826Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e2/1e520793bc6a4e4524a6ab022391e827825eaa0c3811828bfdc6852eca26/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:832d4c998e0b091fd60a6d6bceee535483c4d490de9ba85003af835225719261", size = 1259910, upload-time = "2026-05-17T17:47:41.369Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/e1/49b60f467979979cfe6913b43948ff25bca971ad0591d181812f163a988e/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:16db7c62ec0b8efe1d7afd283a388d8f74f2605d56032e5a37747d2de8dba027", size = 1250678, upload-time = "2026-05-17T17:47:43.702Z" },
+    { url = "https://files.pythonhosted.org/packages/74/ba/66ab9555de6275677566f6574e5ef6c29cb185ea866f643bc06f8280a8ee/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:baf5eb061eb5bccade4128ad42da33787d72f6013809cd1b590376ece8b3c937", size = 1301603, upload-time = "2026-05-17T17:47:46.256Z" },
+    { url = "https://files.pythonhosted.org/packages/66/42/6aca9b9abc710014b2be9059689e5dd1679339e78f567ffb4d255a9e2050/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:104e4a35bd7c124173c41760ef9aaea17ddb3f86c65cb643671d59afbe3ee94c", size = 1410332, upload-time = "2026-05-17T17:47:47.899Z" },
+    { url = "https://files.pythonhosted.org/packages/47/68/2f76594432a22581ecf878b5e75a9b8601c24b2241cf0bbeb1e21fcf370c/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:36be371028fc1675acb38a331bde160dbab7ff907fdf00b67eb6911aa106951b", size = 1509979, upload-time = "2026-05-17T17:47:50.942Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ac/a93c9b58292653f6c595752f677a08e608f903b710594909e9231a389b3b/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:061ee58bdb52341c8201a6df41182a977736bae3b7ded87ca7176ca25a8a47ab", size = 1505002, upload-time = "2026-05-17T17:47:54.093Z" },
+    { url = "https://files.pythonhosted.org/packages/14/2e/b278f68c497ee2f1d1576cbbef8db5281cd4a5f2db040537592ac9c8862e/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b15219e9cdc9f53f6f4cb51c009203507228226148c05c5e8fe451c28b435eb3", size = 1456231, upload-time = "2026-05-17T17:47:56.311Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/419be1c566a4c504cd8fd60ce2f84e790f295495c0f327cfaeadf3d51012/ast_serialize-0.5.0-cp314-cp314t-win32.whl", hash = "sha256:842d1c004bb466c7df036f95fabef789570541922b10976b12f5592a69cf0b38", size = 1058668, upload-time = "2026-05-17T17:47:58.305Z" },
+    { url = "https://files.pythonhosted.org/packages/03/6f/c9d4d549295ed05111aeb8853232d1afd9d0a179fddb01eeffbb3a4a6842/ast_serialize-0.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b0c06d760909b095cc466356dfccd05a1c7233a6ca191c020dca2c6a6f16c24c", size = 1101075, upload-time = "2026-05-17T17:48:00.35Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/8e/d00c5ab30c58222e07d62956fca86c59d91b9ad32997e633c38b526623a3/ast_serialize-0.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:787baedb0262cc49e8ce37cc15c00ae818e46a165a3b36f5e21ed174998104cb", size = 1075347, upload-time = "2026-05-17T17:48:01.753Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/9e/dc2530acb3a60dc6e46d65abf27d1d9f86721694757906a148d90a6860de/ast_serialize-0.5.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:0668aa9459cfa8c9c49ddd2163ebcf43088ba045ef7492af6fe22e0098303101", size = 1191380, upload-time = "2026-05-17T17:48:03.738Z" },
+    { url = "https://files.pythonhosted.org/packages/26/0a/bd3d18a582f273d6c843d16bb9e22e9e16365ff7991e92f18f798e9f1224/ast_serialize-0.5.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:bf683d6363edf2b39eed6b6d4fe22d34b6203867a67e27134d9e2a2680c4bc4a", size = 1183879, upload-time = "2026-05-17T17:48:05.463Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ae/1f919100f8620887af58fcc381c61a1f218cdf89c6e155f87b213e61010a/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cc22cf0c9be65e71cf88fda130af60d61eb4a79370ad4cfe7900d48a4aa2211", size = 1244529, upload-time = "2026-05-17T17:48:07.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/ca/6376559dcce707cdbc1d0d9a13c8d3baaaa501e949ce0ebdc4230cd881aa/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f66173891548c9f2726bf27957b41cabce12fa679dc6da505ddbde4d4b3b31cf", size = 1240560, upload-time = "2026-05-17T17:48:08.46Z" },
+    { url = "https://files.pythonhosted.org/packages/35/b2/a620e206b5aeb7efbf2710336df57d457cffbb3991076bbcc1147ef9abd4/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e42d729ef2be96a14efbad355093284739e3670ece3e534f82cc8832790911d9", size = 1451172, upload-time = "2026-05-17T17:48:09.922Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/e0/4ad5c04c24a40481b2935ce9a0ccdb6023dc8b667167d06ae530cc3512f2/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b725026bafa801dbd7310eb13a75f0a2e370e7e51b2cb225f9d21fcfadf919ee", size = 1265072, upload-time = "2026-05-17T17:48:11.469Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/71/4d1d479aa56d0101c40e17720c3d6ac2af7269ea0487a80b18e7bfd1a5b7/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b54f60c1d78767a53b67eaa663f0dfac3afe606aa07f1301572f588b73d64809", size = 1270488, upload-time = "2026-05-17T17:48:13.575Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/4f/0de1bbe06f6edef9fde4ed12ca8e7b3ec7e6e2bd4e672c5af487f7957665/ast_serialize-0.5.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:27d51654fc240a1e87e742d353d98eb45b75f62f129086b3596ab53df2ac2a43", size = 1260702, upload-time = "2026-05-17T17:48:15.141Z" },
+    { url = "https://files.pythonhosted.org/packages/75/61/e00872439cfdddcc3c1b6cdaa6e5d904ba8e26a18807c67c4e14409d0ca8/ast_serialize-0.5.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c36237c46dd1674542f2109740ea5ea485a169bf1431939ada0434e17934", size = 1311182, upload-time = "2026-05-17T17:48:16.779Z" },
+    { url = "https://files.pythonhosted.org/packages/76/8e/699a5b955f7926956c95e9e1d74132acad73c2fe7a426f94da89123c20aa/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1943db345233cc7194a470f13afa9c59772c0b123dea0c9414c4d4ca54369759", size = 1421410, upload-time = "2026-05-17T17:48:18.527Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ae/d5b7626874478997adc7a29ab28accf21e596fb590c944290401dfd0b29e/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:df1c00022cbbcb064bfaa505aa9c9295362443ce5dacb459d1331d3da353f887", size = 1516587, upload-time = "2026-05-17T17:48:20.133Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ce/b59e02a82d9c4244d64cde502e0b00e83e38816abe19155ceb5437402c7f/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:cae65289fc456fde04af979a2be09302ef5d8ab92ef23e596d6746dc267ada27", size = 1515171, upload-time = "2026-05-17T17:48:21.921Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/38/d8d90042747d05aa08d4efcf1c99035a5f670a6bf4c214d31644392afbca/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:239a4c354e8d676e9d94631d1d4a64edc6b266f86ff3a5a80aedd344f342c01d", size = 1464668, upload-time = "2026-05-17T17:48:23.544Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/51/5b840c4df7334104cecffa28f23904fe81ca89ca223d2450e288de39fd3c/ast_serialize-0.5.0-cp39-abi3-win32.whl", hash = "sha256:143a4ef63285a075871908fda3672dc21864b83a8ec3ee12304aa3e4c5387b9a", size = 1068311, upload-time = "2026-05-17T17:48:25.027Z" },
+    { url = "https://files.pythonhosted.org/packages/41/11/ca5672c7d491825bc4cd6702dea106a6b60d928707712ec257c7833ae476/ast_serialize-0.5.0-cp39-abi3-win_amd64.whl", hash = "sha256:cf25572c526add400f26a4750dc6ce0c3bb93fc1f75e7ae0cad4ce4f2cd5c590", size = 1108931, upload-time = "2026-05-17T17:48:26.591Z" },
+    { url = "https://files.pythonhosted.org/packages/45/19/cc8bd127d28a43da249aa955cfd164cf8fd534e79e42cea96c4854d72fd0/ast_serialize-0.5.0-cp39-abi3-win_arm64.whl", hash = "sha256:92a31c9c20d25a076edaeec76b128a3535d74a24f340b9a8a7e96c9b86dc9642", size = 1081181, upload-time = "2026-05-17T17:48:28.122Z" },
 ]
 
 [[package]]
@@ -326,6 +370,66 @@ wheels = [
 ]
 
 [[package]]
+name = "librt"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/08/9e7f6b5d2b5bed6ad055cdd5925f192bb403a51280f86b56554d9d0699a2/librt-0.11.0.tar.gz", hash = "sha256:075dc3ef4458a278e0195cbf6ac9d38808d9b906c5a6c7f7f79c3888276a3fb1", size = 200139, upload-time = "2026-05-10T18:17:25.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/d0/07c77e067f0838949b43bd89232c29d72efebb9d2801a9750184eb706b71/librt-0.11.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b87504f1690a23b9a2cca841191a04f83895d4fc2dd04df91d82b1a04ca2ad46", size = 144147, upload-time = "2026-05-10T18:15:53.227Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/24/8493538fa4f62f982686398a5b8f68008138a75086abdea19ade64bf4255/librt-0.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40071fc5fe0ce8daa6de616702314a01e1250711682b0523d6ab8d4525910cb3", size = 143614, upload-time = "2026-05-10T18:15:54.657Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1e/f8bad050810d9171f34a1648ed910e56814c2ba61639f2bd53c6377ae24b/librt-0.11.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:137e79445c896a0ea7b265f52d23954e05b64222ee1af69e2cb34219067cbb67", size = 485538, upload-time = "2026-05-10T18:15:56.117Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/fe/3594ebfbaf03084ba4b120c9ba5c3183fd938a48725e9bbe6ff0a5159ad8/librt-0.11.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:cca6644054e78746d8d4ef238681f9c34ff8b584fe6b988ecebb8db3b15e622a", size = 479623, upload-time = "2026-05-10T18:15:57.544Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/da/5d1876984b3746c85dbd219dbfcb73c85f54ee263fd32e5b2a632ec14571/librt-0.11.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d5b0eea49f5562861ee8d757a32ef7d559c1d35be2aaaa1ec28941d74c9ffc8a", size = 513082, upload-time = "2026-05-10T18:15:58.805Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6e/55bdf5d5ca00c3e18430690bf2c953d8d3ffd3c337418173d33dec985dc9/librt-0.11.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0d1029d7e1ae1a7e647ed6fb5df8c4ce2dffefb7a9f5fd1376a4554d96dac09f", size = 508105, upload-time = "2026-05-10T18:16:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/07/10/f1f23a7c595ee90ece4d35c851e5d104b1311a887ed1b4ac4c35bbd13da8/librt-0.11.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bc3ce6b33c5828d9e80592011a5c584cb2ce86edbc4088405f70da47dc1d1b3b", size = 522268, upload-time = "2026-05-10T18:16:01.708Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/02/5720f5697a7f54b78b3aefbe20df3a48cedcff1276618c4aa481177942ed/librt-0.11.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:936c5995f3514a42111f20099397d8177c79b4d7e70961e396c6f5a0a3566766", size = 527348, upload-time = "2026-05-10T18:16:03.496Z" },
+    { url = "https://files.pythonhosted.org/packages/50/db/b4a47c6f91db4ff76348a0b3dd0cc65e090a078b765a810a62ff9434c3d3/librt-0.11.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:9bc0ca6ad9381cbe8e4aa6e5726e4c80c78115a6e9723c599ed1d73e092bc49d", size = 516294, upload-time = "2026-05-10T18:16:05.173Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/58/9384b2f4eb1ed1d273d40948a7c5c4b2360213b402ef3be4641c06299f9c/librt-0.11.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:070aa8c26c0a74774317a72df8851facc7f0f012a5b406557ac56992d92e1ec8", size = 553608, upload-time = "2026-05-10T18:16:06.839Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7b/5aa8848a7c6a9278c79375146da1812e695754ceec5f005e6043461a7315/librt-0.11.0-cp312-cp312-win32.whl", hash = "sha256:6bf14feb84b05ae945277395451998c89c54d0def4070eb5c08de544930b245a", size = 101879, upload-time = "2026-05-10T18:16:08.103Z" },
+    { url = "https://files.pythonhosted.org/packages/37/33/8a745436944947575b584231750a41417de1a38cf6a2e9251d1065651c09/librt-0.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:75672f0bc524ede266287d532d7923dbce94c7514ad07627bac3d0c6d92cc4d9", size = 119831, upload-time = "2026-05-10T18:16:09.174Z" },
+    { url = "https://files.pythonhosted.org/packages/59/67/a6739ac96e28b7855808bdb0370e250606104a859750d209e5a0716fe7ab/librt-0.11.0-cp312-cp312-win_arm64.whl", hash = "sha256:2f10cf143e4a9bb0f4f5af568a00df94a2d69ef41c2579584454bb0fe5cc642c", size = 103470, upload-time = "2026-05-10T18:16:10.369Z" },
+    { url = "https://files.pythonhosted.org/packages/82/61/e59168d4d0bf2bf90f4f0caf7a001bfc60254c3af4586013b04dc3ef517b/librt-0.11.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:78dc31f7fdfe9c9d0eb0e8f42d139db230e826415bbcabd9f0e9faaaee909894", size = 144119, upload-time = "2026-05-10T18:16:11.771Z" },
+    { url = "https://files.pythonhosted.org/packages/61/fd/caa1d60b12f7dd79ccea23054e06eeaebe266a5f52c40a6b651069200ce5/librt-0.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fa475675db22290c3158e1d42326d0f5a65f04f44a0e68c3630a25b53560fb9c", size = 143565, upload-time = "2026-05-10T18:16:13.334Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/dc744f5c2b4978d48db970be29f22716d3413d28b14ad99740817315cf2c/librt-0.11.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:621db29691044bdeda22e789e482e1b0f3a985d90e3426c9c6d17606416205ea", size = 485395, upload-time = "2026-05-10T18:16:14.729Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/21/7f8e97a1e4dae952a5a95948f6f8507a173bc1e669f54340bba6ca1ca31b/librt-0.11.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:a9010e2ed5b3a9e158c5fd966b3ab7e834bb3d3aacc8f66c91dd4b57a3799230", size = 479383, upload-time = "2026-05-10T18:16:16.321Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/6d/d8ee9c114bebf2c50e29ec2aa940826fccb62a645c3e4c18760987d0e16d/librt-0.11.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c39513d8b7477a2e1ed8c43fc21c524e8d5a0f8d4e8b7b074dbdbe7820a08e2", size = 513010, upload-time = "2026-05-10T18:16:17.647Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/43/0b5708af2bd30a46400e72ba6bdaa8f066f15fb9a688527e34220e8d6c06/librt-0.11.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7aef3cf1d5af86e770ab04bfd993dfc4ae8b8c17f66fb77dd4a7d50de7bbb1a3", size = 508433, upload-time = "2026-05-10T18:16:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/50/356187247d09013490481033183b3532b58acf8028bcb34b2b56a375c9b2/librt-0.11.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:557183ddc36babe46b27dd60facbd5adb4492181a5be887587d57cda6e092f21", size = 522595, upload-time = "2026-05-10T18:16:20.642Z" },
+    { url = "https://files.pythonhosted.org/packages/40/e7/c6ac4240899c7f3248079d5a9900debe0dadb3fdeaf856684c987105ba47/librt-0.11.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:83d3e1f72bd42f6c5c0b7daec530c3f829bd02db42c70b8ddf0c2d90a2459930", size = 527255, upload-time = "2026-05-10T18:16:22.352Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/b5/a81322dbeedeeaf9c1ee6f001734d28a09d8383ac9e6779bc24bbd0743c6/librt-0.11.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:4ce1f21fbe589bc1afd7872dece84fb0e1144f794a288e58a10d2c54a55c43be", size = 516847, upload-time = "2026-05-10T18:16:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/66/6e6323787d592b55204a42595ff1102da5115601b53a7e9ddebc889a6da5/librt-0.11.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b09f7044ea2b64c9da42fd3d335666518cfd1c6e8a182c95da73d0214b41e", size = 553920, upload-time = "2026-05-10T18:16:25.025Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/21/623f8ca230857102066d9ca8c6c1734995908c4d0d1bee7bb2ef0021cb33/librt-0.11.0-cp313-cp313-win32.whl", hash = "sha256:78fddc31cd4d3caa897ad5d31f856b1faadc9474021ad6cb182b9018793e254e", size = 101898, upload-time = "2026-05-10T18:16:26.649Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/1d/b4ebd44dd723f768469007515cb92251e0ae286c94c140f374801140fa74/librt-0.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:8ca8aa88751a775870b764e93bad5135385f563cb8dcee399abf034ea4d3cb47", size = 119812, upload-time = "2026-05-10T18:16:27.859Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/e4/b2f4ca7965ca373b491cdb4bc25cdb30c1649ca81a8782056a83850292a9/librt-0.11.0-cp313-cp313-win_arm64.whl", hash = "sha256:96f044bb325fd9cf1a723015638c219e9143f0dfbc0ca54c565df2b7fc748b44", size = 103448, upload-time = "2026-05-10T18:16:29.066Z" },
+    { url = "https://files.pythonhosted.org/packages/29/eb/dbce197da4e227779e56b5735f2decc3eb36e55a1cdbf1bd65d6639d76c1/librt-0.11.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4a017a95e5837dc15a8c5661d60e05daa96b90908b1aa6b7acdf443cd25c8ebd", size = 143345, upload-time = "2026-05-10T18:16:30.674Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a3/254bebd0c11c8ba684018efb8006ff22e466abce445215cca6c778e7d9de/librt-0.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b1ecbd9819deccc39b7542bf4d2a740d8a620694d39989e58661d3763458f8d4", size = 143131, upload-time = "2026-05-10T18:16:32.037Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/3f/f77d6122d21ac7bf6ae8a7dfced1bd2a7ac545d3273ebdcaf8042f6d619f/librt-0.11.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7da327dacd7be8f8ec36547373550744a3cc0e536d54665cd83f8bcd961200e8", size = 477024, upload-time = "2026-05-10T18:16:33.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/0a/2c996dadebaa7d9bbbd43ef2d4f3e66b6da545f838a41694ef6172cebec8/librt-0.11.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0dc56b1f8d06e60db362cc3fdae206681817f86ce4725d34511473487f12a34b", size = 474221, upload-time = "2026-05-10T18:16:34.864Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/7e/f5d92af8486b8272c23b3e686b46ff72d89c8169585eb61eef01a2ac7147/librt-0.11.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05fb8fb2ab90e21c8d12ea240d744ad514da9baf381ebfa70d91d20d21713175", size = 505174, upload-time = "2026-05-10T18:16:36.705Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1a/cb0734fe86398eb33193ab753b7326255c74cac5eb09e76b9b16536e7adb/librt-0.11.0-cp314-cp314-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cae74872be221df4374d10fec61f93ed1513b9546ea84f2c0bf73ab3e9bd0b03", size = 497216, upload-time = "2026-05-10T18:16:38.418Z" },
+    { url = "https://files.pythonhosted.org/packages/18/06/094820f91558b66e29943c0ec41c9914f460f48dd51fc503c3101e10842d/librt-0.11.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32bcc918c0148eb7e3d57385125bac7e5f9e4359d05f07448b09f6f778c2f31c", size = 513921, upload-time = "2026-05-10T18:16:39.848Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/c2/00de9018871a282f530cacb457d5ec0428f6ac7e6fedde9aff7468d9fb04/librt-0.11.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:f9743fc99135d5f78d2454435615f6dec0473ca507c26ce9d92b10b562a280d3", size = 520850, upload-time = "2026-05-10T18:16:41.471Z" },
+    { url = "https://files.pythonhosted.org/packages/51/9d/64631832348fd1834fb3a61b996434edddaaf25a31d03b0a76273159d2cf/librt-0.11.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5ba067f4aadae8fda802d91d2124c90c42195ff32d9161d3549e6d05cfe26f96", size = 504237, upload-time = "2026-05-10T18:16:43.15Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ec/ae5525eb16edc827a044e7bb8777a455ff95d4bca9379e7e6bddd7383647/librt-0.11.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:de3bf945454d032f9e390b85c4072e0a0570bf825421c8be0e71209fa65e1abe", size = 546261, upload-time = "2026-05-10T18:16:44.408Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/09/adce371f27ca039411da9659f7430fcc2ba6cd0c7b3e4467a0f091be7fa9/librt-0.11.0-cp314-cp314-win32.whl", hash = "sha256:d2277a05f6dcb9fd13db9566aac4fabd68c3ea1ea46ee5567d4eef8efa495a2f", size = 96965, upload-time = "2026-05-10T18:16:46.039Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ee/8ac720d98548f173c7ce2e632a7ca94673f74cacd5c8162a84af5b35958a/librt-0.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:ab73e8db5e3f564d812c1f5c3a175930a5f9bc96ccb5e3b22a34d7858b401cf7", size = 115151, upload-time = "2026-05-10T18:16:47.133Z" },
+    { url = "https://files.pythonhosted.org/packages/94/20/c900cf14efeb09b6bef2b2dff20779f73464b97fd58d1c6bccc379588ae3/librt-0.11.0-cp314-cp314-win_arm64.whl", hash = "sha256:aea3caa317752e3a466fa8af45d91ee0ea8c7fdd96e42b0a8dd9b76a7931eba1", size = 98850, upload-time = "2026-05-10T18:16:48.597Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/71/944bfe4b64e12abffcd3c15e1cce07f72f3d55655083786285f4dedeb532/librt-0.11.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d1b36540d7aaf9b9101b3a6f376c8d8e9f7a9aec93ed05918f2c69d493ffef72", size = 151138, upload-time = "2026-05-10T18:16:49.839Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/10/99e64a5c86989357fda078c8143c533389585f6473b7439172dd8f3b3b2d/librt-0.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:efbb343ab2ce3540f4ecbe6315d677ed70f37cd9a72b1e58066c918ca83acbaa", size = 151976, upload-time = "2026-05-10T18:16:51.062Z" },
+    { url = "https://files.pythonhosted.org/packages/21/31/5072ad880946d83e5ea4147d6d018c78eefce85b77819b19bdd0ee229435/librt-0.11.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0dd688aab3f7914d3e6e5e3554978e0383312fb8e771d84be008a35b9ee548", size = 557927, upload-time = "2026-05-10T18:16:52.632Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/8d/70b5fb7cfbab60edbe7381614ab985da58e144fbf465c86d44c95f43cdca/librt-0.11.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:f5fb36b8c6c63fdcbb1d526d94c0d1331610d43f4118cc1beb4efef4f3faacb2", size = 539698, upload-time = "2026-05-10T18:16:53.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a3/ba3495a0b3edbd24a4cae0d1d3c64f39a9fc45d06e812101289b50c1a619/librt-0.11.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4a9a237d13addb93715b6fee74023d5ee3469b53fce527626c0e088aa585805f", size = 577162, upload-time = "2026-05-10T18:16:55.589Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/db/36e25fb81f99937ff1b96612a1dc9fd66f039cb9cc3aee12c01fac31aab9/librt-0.11.0-cp314-cp314t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5ddd17bd87b2c56ddd60e546a7984a2e64c4e8eab92fb4cf3830a48ad5469d51", size = 566494, upload-time = "2026-05-10T18:16:56.975Z" },
+    { url = "https://files.pythonhosted.org/packages/33/0d/3f622b47f0b013eeb9cf4cc07ae9bfe378d832a4eec998b2b209fe84244d/librt-0.11.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd43992b4473d42f12ff9e68326079f0696d9d4e6000e8f39a0238d482ba6ee2", size = 596858, upload-time = "2026-05-10T18:16:58.374Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/02/71b90bc93039c46a2000651f6ad60122b114c8f54c4ad306e0e96f5b75ad/librt-0.11.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:f8e3e8056dd674e279741485e2e512d6e9a751c7455809d0114e6ebf8d781085", size = 590318, upload-time = "2026-05-10T18:16:59.676Z" },
+    { url = "https://files.pythonhosted.org/packages/04/04/418cb3f75621e2b761fb1ab0f017f4d70a1a72a6e7c74ee4f7e8d198c2f3/librt-0.11.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c1f708d8ae9c56cf38a903c44297243d2ec83fd82b396b977e0144a3e76217e3", size = 575115, upload-time = "2026-05-10T18:17:01.007Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/2c/5a2183ac58dd911f26b5d7e7d7d8f1d87fcecdddd99d6c12169a258ff62c/librt-0.11.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0add982e0e7b9fc14cf4b33789d5f13f66581889b88c2f58099f6ce8f92617bd", size = 617918, upload-time = "2026-05-10T18:17:02.682Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1f/dc6771a52592a4451be6effa200cbfc9cec61e4393d3033d81a9d307961d/librt-0.11.0-cp314-cp314t-win32.whl", hash = "sha256:2b481d846ac894c4e8403c5fd0e87c5d11d6499e404b474602508a224ff531c8", size = 103562, upload-time = "2026-05-10T18:17:03.99Z" },
+    { url = "https://files.pythonhosted.org/packages/62/4a/7d1415567027286a75ba1093ec4aca11f073e0f559c530cf3e0a757ad55c/librt-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:28edb433edde181112a908c78907af28f964eabc15f4dd16c9d66c834302677c", size = 124327, upload-time = "2026-05-10T18:17:05.465Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/62/b40b382fa0c66fee1478073eb8db352a4a6beda4a1adccf1df911d8c289c/librt-0.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dee008f20b542e3cd162ba338a7f9ec0f6d23d395f66fe8aeeec3c9d067ea253", size = 102572, upload-time = "2026-05-10T18:17:06.809Z" },
+]
+
+[[package]]
 name = "logistro"
 version = "2.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -480,6 +584,59 @@ wheels = [
 ]
 
 [[package]]
+name = "mypy"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/15/cca9d88503549ed6fedeaa1d448cdddd542ee8a490232d732e278036fbf2/mypy-2.1.0.tar.gz", hash = "sha256:81e76ad12c2d804512e9b13240d1588316531bfba07558286078bfbce9613633", size = 3898359, upload-time = "2026-05-11T18:37:36.237Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/b1/55861beb5c339b44f9a2ba92df9e2cb1eeb4ae1eee674cdf7772c797778b/mypy-2.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:244358bf1c0da7722230bce60683d52e8e9fd030554926f15b747a84efb5b3af", size = 14874381, upload-time = "2026-05-11T18:37:31.784Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b3/b7f770114b7d0ac92d0f76e8d93c2780844a70488a90e91821927850da86/mypy-2.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4ec7c57657493c7a75534df2751c8ae2cda383c16ecc55d2106c54476b1b16f6", size = 13665501, upload-time = "2026-05-11T18:34:23.063Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f3/8ae2037967e2126689a0c11d99e2b707134a565191e92c60ca2572aec60a/mypy-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8161b6ff4392410023224f0969d17db93e1e154bc3e4ba62598e720723ae211", size = 14045750, upload-time = "2026-05-11T18:31:48.151Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/32/615eb5911859e43d054941b0d0a7d06cfa2870eba86529cf385b052b111c/mypy-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf03e12003084a67395184d3eb8cbd6a489dc3655b5664b28c210a9e2403ab0b", size = 15061630, upload-time = "2026-05-11T18:37:06.898Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/03/4eafbfff8bfab1b87082741eae6e6a624028c984e6708b73bce2a8570c9d/mypy-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:20509760fd791c51579d573153407d226385ec1f8bcce55d730b354f3336bc22", size = 15288831, upload-time = "2026-05-11T18:31:18.07Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ee/919661478e5891a3c96e549c036e467e64563ab85995b10c53c8358e16a3/mypy-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:6753d0c1fdd6b1a23b9e4f283ce80b2153b724adcb2653b20b85a8a28ac6436b", size = 11135228, upload-time = "2026-05-11T18:34:31.23Z" },
+    { url = "https://files.pythonhosted.org/packages/24/0a/6a12b9782ca0831a553192f351679f4548abc9d19a7cc93bb7feb02084c7/mypy-2.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:98ebb6589bb3b6d0c6f0c459d53ca55b8091fbc13d277c4041c885392e8195e8", size = 10040684, upload-time = "2026-05-11T18:36:48.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/dd/c7191469c777f07689c032a8f7326e393ea34c92d6d76eb7ce5ba57ea66d/mypy-2.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:35aac3bb114e03888f535d5eb51b8bafbb3266586b599da1940f9b1be3ec5bd5", size = 14852174, upload-time = "2026-05-11T18:31:38.929Z" },
+    { url = "https://files.pythonhosted.org/packages/55/8c/aed55408879043d72bb9135f4d0d19a02b886dd569631e113e3d2706cb8d/mypy-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8de55a8c861f2a49331f807be98d90caeceeef520bde13d43a160207f8af613e", size = 13651542, upload-time = "2026-05-11T18:36:04.636Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8e/f371a824b1f1fa8ea6e3dbb8703d232977d572be2329554a3bc4d960302f/mypy-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5fdf2941a07434af755837d9880f7d7d25f1dacb1af9dcd4b9b66f2220a3024e", size = 14033929, upload-time = "2026-05-11T18:35:55.742Z" },
+    { url = "https://files.pythonhosted.org/packages/94/21/f54be870d6dd53a82c674407e0f8eed7174b05ec78d42e5abd7b42e84fd5/mypy-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e195b817c13f02352a9c124301f9f30f078405444679b6753c1b96b6eed37285", size = 15039200, upload-time = "2026-05-11T18:33:10.281Z" },
+    { url = "https://files.pythonhosted.org/packages/17/99/bf21748626a40ce59fd29a39386ab46afec88b7bd2f0fa6c3a97c995523f/mypy-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5431d42af987ebd92ba2f71d45c85ed41d8e6ca9f5fd209a69f68f707d2469e5", size = 15272690, upload-time = "2026-05-11T18:32:07.205Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/d7/9e90d2cf47100bea550ed2bc7b0d4de3a62181d84d5e37da0003e8462637/mypy-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:767fe8c66dc3e01e19e1737d4c38ebefead16125e1b8e58ad421903b376f5c65", size = 11147435, upload-time = "2026-05-11T18:33:56.477Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/46/e5c449e858798e35ffc90946282a27c62a77be743fe17480e4977374eb91/mypy-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:ecfe70d43775ab99562ab128ce49854a362044c9f894961f68f898c23cb7429d", size = 10035052, upload-time = "2026-05-11T18:32:30.049Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ca/b279a672e874aedd5498ae25f722dacc8aa86bbffb939b3f97cbb1cf6686/mypy-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7354c5a7f69d9345c3d6e69921d57088eea3ddeeb6b20d34c1b3855b02c36ec2", size = 14848422, upload-time = "2026-05-11T18:35:45.984Z" },
+    { url = "https://files.pythonhosted.org/packages/27/e6/3efe56c631d959b9b4454e208b0ac4b7f4f58b404c89f8bec7b49efdfc21/mypy-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:49890d4f76ac9e06ec117f9e09f3174da70a620a0c300953d8595c926e80947f", size = 13677374, upload-time = "2026-05-11T18:36:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7f/8107ea87a44fd1f1b59882442f033c9c3488c127201b1d1d15f1cbd6022e/mypy-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:761be68e023ef5d94678772396a8af1220030f80837a3afd8d0aef3b419666f4", size = 14055743, upload-time = "2026-05-11T18:35:18.361Z" },
+    { url = "https://files.pythonhosted.org/packages/51/4d/b6d34db183133b83761b9199a82d31557cdbb70a380d8c3b3438e11882a3/mypy-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c90345fc182dc363b891350457ec69c35140858538f38b4540845afcc32b1aef", size = 15020937, upload-time = "2026-05-11T18:34:59.618Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/d7/f08360c691d758acb02f45022c34d98b92892f4ea756644e1000d4b9f3d8/mypy-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b84802e7b5a6daf1f5e15bc9fcd7ddae77be13981ffab037f1c67bb84d67d135", size = 15253371, upload-time = "2026-05-11T18:36:41.081Z" },
+    { url = "https://files.pythonhosted.org/packages/67/1b/09460a13719530a19bce27bd3bc8449e83569dd2ba7faf51c9c3c30c0b61/mypy-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:022c771234936ceac541ebaf836fe9e2abeb3f5e09aff21588fe543ff006fe21", size = 11326429, upload-time = "2026-05-11T18:34:13.526Z" },
+    { url = "https://files.pythonhosted.org/packages/40/62/75dbf0f82f7b6680340efc614af29dd0b3c17b8a4f1cd09b8bd2fd6bc814/mypy-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:498207db725cec88829a6a5c2fc771205fd043719ef98bc49aba8fb9fc4e6d57", size = 10218799, upload-time = "2026-05-11T18:32:23.491Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/66/caca04ed7d972fb6eb6dd1ccd6df1de5c38fae8c5b3dc1c4e8e0d85ee6b9/mypy-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7d5e5cad0efeba72b93cd17490cc0d69c5ac9ca132994fe3fb0314808aeeb83e", size = 15923458, upload-time = "2026-05-11T18:35:28.64Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/52/2d90cbe49d014b13ed7ff337930c30bad35893fe38a1e4641e756bb62191/mypy-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ff715050c127d724fd260a2e666e7747fdd83511c0c47d449d98238970aef780", size = 14757697, upload-time = "2026-05-11T18:36:14.208Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/37/d98f4a14e081b238992d0ed96b6d39c7cc0148c9699eb71eaa68629665ea/mypy-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:82208da9e09414d520e912d3e462d454854bed0810b71540bb016dcbca7308fd", size = 15405638, upload-time = "2026-05-11T18:33:48.249Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/c2/15c46613b24a84fad2aea1248bf9619b99c2767ae9071fe224c179a0b7d4/mypy-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e79ebc1b904b84f0310dff7469655a9c36c7a68bddb37bdd42b67a332df61d08", size = 16215852, upload-time = "2026-05-11T18:32:50.296Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/90/9c16a57f482c76d25f6379762b56bbf65c711d8158cf271fb2802cfb0640/mypy-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e583edc957cfb0deb142079162ae826f58449b116c1d442f2d91c69d9fced081", size = 16452695, upload-time = "2026-05-11T18:33:38.182Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/4c/215a4eeb63cacc5f17f516691ea7285d11e249802b942476bff15922a314/mypy-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b33b6cd332695bba180d55e717a79d3038e479a2c49cc5eb3d53603409b9a5d7", size = 12866622, upload-time = "2026-05-11T18:34:39.945Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/50/1043e1db5f455ffe4c9ab22747cd8ca2bc492b1e4f4e21b130a44ee2b217/mypy-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:4f910fe825376a7b66ef7ca8c98e5a149e8cd64c19ae71d84047a74ee060d4e6", size = 10610798, upload-time = "2026-05-11T18:36:31.444Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/2a/13ca1f292f6db1b98ff495ef3467736b331621c5917cad984b7043e7348d/mypy-2.1.0-py3-none-any.whl", hash = "sha256:a663814603a5c563fb87a4f96fb473eeb30d1f5a4885afcf44f9db000a366289", size = 2693302, upload-time = "2026-05-11T18:31:29.246Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
 name = "narwhals"
 version = "2.21.2"
 source = { registry = "https://pypi.org/simple" }
@@ -627,6 +784,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/30/4b/90c937815137d43ce71ba043cd3566221e9df6b9c805f24b5d138c9d40a7/parso-0.8.7.tar.gz", hash = "sha256:eaaac4c9fdd5e9e8852dc778d2d7405897ec510f2a298071453e5e3a07914bb1", size = 401824, upload-time = "2026-05-01T23:13:02.138Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/5d/8268b644392ee874ee82a635cd0df1773de230bde356c38de28e298392cc/parso-0.8.7-py2.py3-none-any.whl", hash = "sha256:a8926eb2a1b915486941fdbd31e86a4baf88fe8c210f25f2f35ecec5b574ca1c", size = 107025, upload-time = "2026-05-01T23:12:58.867Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]
@@ -778,6 +944,7 @@ dev = [
     { name = "pytest-benchmark" },
 ]
 lint = [
+    { name = "mypy" },
     { name = "pre-commit" },
 ]
 test = [
@@ -804,7 +971,10 @@ dev = [
     { name = "marimo", specifier = ">=0.14.9" },
     { name = "pytest-benchmark", specifier = ">=5.2.3" },
 ]
-lint = [{ name = "pre-commit", specifier = ">=4.0" }]
+lint = [
+    { name = "mypy", specifier = ">=1.14" },
+    { name = "pre-commit", specifier = ">=4.0" },
+]
 test = [
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-cov", specifier = ">=6.0" },


### PR DESCRIPTION
## Summary

- **Typing & API**: ship a `py.typed` marker (PEP 561) and re-export the public API from the package root, so `from pyhrp import hrp, schur_hrp, build_tree, ...` works and downstream type checkers see the annotations
- **Input validation**: reject `gamma` outside `[0, 1]` in Schur allocation; raise clear errors naming the offending assets for zero-variance (constant-price) series and for correlation matrices with fewer than two assets; handle single-asset frames in `compute_cov`/`compute_corr`; `strict=True` zips
- **Numerical robustness**: equal split instead of NaN weights when both child variances are zero; least-squares fallback for singular Schur blocks (collinear assets)
- **Performance**: precompute the covariance array and a name→index map once per allocation instead of per node — at 1000 assets, `hrp` drops 0.40s → 0.05s and `schur_hrp` 0.17s → 0.07s
- **Simplification**: `risk_parity` and `schur_risk_parity` share one `_allocate` traversal; portfolios are rebuilt at every node so repeated allocation on the same tree is idempotent (documented); removed duplicate `Cluster.is_leaf`, extracted shared returns preprocessing
- **Tooling**: mypy in strict mode (pyproject config + pre-commit hook); ruff target bumped to py312 (PEP 695 generics in `treelib`); Python 3.14 classifier
- **Docs**: README examples use the top-level imports and match the library's internal returns handling (validated by the rhiza README-execution test)

Note: `ruff.toml` and `.pre-commit-config.yaml` are rhiza-template-synced; the py312 bump and the mypy hook may be worth upstreaming to the template.

## Test plan

- [x] 106 tests pass (11 new edge-case tests in `tests/test_validation.py`)
- [x] Doctests pass (`pytest --doctest-modules src/pyhrp`)
- [x] mypy strict clean on `src/`
- [x] Full pre-commit suite passes, including the new mypy hook
- [x] `py.typed` confirmed present in the built wheel
- [x] Before/after benchmark at 300 and 1000 assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Direct imports from `pyhrp` namespace for all key functions and classes.

* **Bug Fixes**
  * Enhanced input validation with clearer error messages for invalid parameters and edge cases.

* **Documentation**
  * Updated README examples with new import patterns.

* **Chores**
  * Python target version updated to 3.12; Python 3.14 classifier added.
  * Removed `Cluster.is_leaf` property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->