### PR TITLE
Fix: build API docs without an editable install (mkdocstrings paths: src)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,19 @@ nav:
     - Test Report: reports/html-report/report.html
     - Coverage Report: reports/html-coverage/index.html
 
+# Tell mkdocstrings/griffe where the src-layout package lives so API docs build
+# by static analysis of the source, without an editable install. The rhiza book
+# command intentionally no longer installs the package editable
+# (see .rhiza/tests/integration/test_docs_targets.py::
+# test_default_book_command_does_not_use_editable_install), so a src-layout
+# project must point the handler at src/ itself.
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [src]
+
 extra:
   social:
     - icon: fontawesome/brands/github


### PR DESCRIPTION
## Problem

After the v0.19.3 Rhiza sync (#705), the **book** CI job fails:

```
mkdocstrings: accessing 'pyhrp' raises ModuleNotFoundError: No module named 'pyhrp'
Python error: PluginError: Could not collect 'pyhrp.hrp'
make: *** [.rhiza/make.d/book.mk:52: book] Error 1
```

v0.19.3 intentionally dropped `--with-editable .` from the book command and added a managed test (`.rhiza/tests/integration/test_docs_targets.py::test_default_book_command_does_not_use_editable_install`) that forbids it. With no editable install, mkdocstrings/griffe can no longer **import** `pyhrp` to build the API reference — and this is a `src/`-layout project, so the package isn't importable from the repo root either.

## Fix

Point the mkdocstrings python handler at `src/` in the **repo-owned** `mkdocs.yml`, so griffe analyses the package **statically from source** — no install required:

```yaml
plugins:
  - search
  - mkdocstrings:
      handlers:
        python:
          paths: [src]
```

`paths` is genuinely project-specific (it depends on this repo's `src/` layout), so it belongs in the repo's `mkdocs.yml`, not in the managed `docs/mkdocs-base.yml`. The `INHERIT` deep-merge preserves the base handler options (`docstring_style`, `show_source`, symbol headings, …) and only adds `paths`.

## Verification (local)
- `make book` → **exit 0**, full API reference rendered (`pyhrp.hrp`/`algos`/`cluster`/`treelib`), **0 collect errors**.
- The managed test `test_default_book_command_does_not_use_editable_install` still **passes** (3 passed) — the book command remains free of `--with-editable .`.
- `make fmt` → PASS.

## Upstream consideration for Rhiza

Dropping `--with-editable .` breaks the book build for **any `src`-layout project doing API autodoc** unless they set `paths: [src]`. Worth considering upstream in `jebel-quant/rhiza`: either document this requirement in `docs/mkdocs-base.yml`, or default the python handler to `paths: [src]` (a no-op for flat-layout repos). Flagging rather than fixing here since the per-repo `paths` value is layout-dependent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)