### PR TITLE
Refactor: extract plotly dendrogram rendering into pyhrp.plot

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -27,4 +27,8 @@ from pyhrp.cluster import Cluster, Portfolio
 
 ---
 
+::: pyhrp.plot
+
+---
+
 ::: pyhrp.treelib

--- a/src/pyhrp/hrp.py
+++ b/src/pyhrp/hrp.py
@@ -11,16 +11,18 @@ This module implements the core HRP algorithm and related functions:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
-import plotly.graph_objects as go
 import polars as pl
 import scipy.cluster.hierarchy as sch
 import scipy.spatial.distance as ssd
 
 from .algos import risk_parity, schur_risk_parity
 from .cluster import Cluster
+
+if TYPE_CHECKING:
+    import plotly.graph_objects as go
 
 __all__ = ["Dendrogram", "build_tree", "compute_corr", "compute_cov", "hrp", "schur_hrp"]
 
@@ -175,24 +177,14 @@ class Dendrogram:
             raise ValueError("Number of leaves does not match number of assets.")  # noqa: TRY003
 
     def plot(self, **kwargs: object) -> go.Figure:
-        """Build and return a plotly dendrogram figure."""
-        if self.linkage is None:
-            msg = "Dendrogram has no linkage matrix to plot."
-            raise ValueError(msg)
-        ddata = sch.dendrogram(self.linkage, labels=self.assets, no_plot=True, **kwargs)
-        fig = go.Figure()
-        for xs, ys in zip(ddata["icoord"], ddata["dcoord"], strict=False):
-            fig.add_trace(go.Scatter(x=xs, y=ys, mode="lines", line={"color": "steelblue"}, showlegend=False))
-        n = len(self.assets)
-        fig.update_layout(
-            xaxis={
-                "tickmode": "array",
-                "tickvals": [5 + 10 * i for i in range(n)],
-                "ticktext": ddata["ivl"],
-                "tickangle": -90,
-            },
-        )
-        return fig
+        """Build and return a plotly dendrogram figure.
+
+        Delegates to :func:`pyhrp.plot.plot_dendrogram`; the plotly dependency
+        is imported lazily so importing the allocation core stays plotly-free.
+        """
+        from .plot import plot_dendrogram
+
+        return plot_dendrogram(self, **kwargs)
 
     @property
     def ids(self) -> list[int]:

--- a/src/pyhrp/plot.py
+++ b/src/pyhrp/plot.py
@@ -1,0 +1,61 @@
+"""Plotly visualization for hierarchical clustering dendrograms.
+
+Kept separate from the allocation core (``hrp.py``) so that the optional
+plotting dependency (plotly) and the visualization logic do not couple the
+algorithm modules. ``Dendrogram.plot`` delegates here.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import plotly.graph_objects as go
+import scipy.cluster.hierarchy as sch
+
+if TYPE_CHECKING:
+    from .hrp import Dendrogram
+
+__all__ = ["plot_dendrogram"]
+
+
+def plot_dendrogram(dendrogram: Dendrogram, **kwargs: object) -> go.Figure:
+    """Build and return a plotly dendrogram figure for a Dendrogram.
+
+    Args:
+        dendrogram (Dendrogram): Clustering result carrying the linkage matrix
+            and asset labels to render.
+        **kwargs (object): Extra keyword arguments forwarded to
+            ``scipy.cluster.hierarchy.dendrogram`` (e.g. ``color_threshold``).
+
+    Returns:
+        go.Figure: A plotly figure drawing the dendrogram as line traces.
+
+    Raises:
+        ValueError: If the dendrogram has no linkage matrix to plot.
+
+    Examples:
+        >>> import polars as pl
+        >>> from pyhrp.hrp import build_tree
+        >>> from pyhrp.plot import plot_dendrogram
+        >>> cor = pl.DataFrame({"A": [1.0, 0.5], "B": [0.5, 1.0]})
+        >>> fig = plot_dendrogram(build_tree(cor, method="ward"))
+        >>> type(fig).__name__
+        'Figure'
+    """
+    if dendrogram.linkage is None:
+        msg = "Dendrogram has no linkage matrix to plot."
+        raise ValueError(msg)
+    ddata = sch.dendrogram(dendrogram.linkage, labels=dendrogram.assets, no_plot=True, **kwargs)
+    fig = go.Figure()
+    for xs, ys in zip(ddata["icoord"], ddata["dcoord"], strict=False):
+        fig.add_trace(go.Scatter(x=xs, y=ys, mode="lines", line={"color": "steelblue"}, showlegend=False))
+    n = len(dendrogram.assets)
+    fig.update_layout(
+        xaxis={
+            "tickmode": "array",
+            "tickvals": [5 + 10 * i for i in range(n)],
+            "ticktext": ddata["ivl"],
+            "tickangle": -90,
+        },
+    )
+    return fig


### PR DESCRIPTION
## Summary
- Move the plotly figure-building logic out of `hrp.py` into a new `pyhrp.plot` module
- `Dendrogram.plot` now delegates to `plot_dendrogram` and imports plotly lazily, so importing the allocation core stays plotly-free
- Document the new module in `docs/api.md`

## Test plan
- [x] `import pyhrp.hrp` and `import pyhrp.plot` succeed
- [x] `build_tree(...).plot()` returns a plotly `Figure`
- [x] pre-commit hooks (ruff, mypy, interrogate, bandit) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)