### PR TITLE
style: consolidate src/ TRY003 suppressions into a ruff per-file-ignore

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -123,6 +123,12 @@ line-ending = "auto"
 
 # File-specific rule exceptions
 [lint.per-file-ignores]
+# Library source - long, descriptive exception messages are intentional at our
+# scale (see the EM note above); express that policy once here instead of
+# scattering inline `# noqa: TRY003` across the modules.
+"src/pyhrp/*.py" = [
+    "TRY003",   # Allow long exception messages in the library source
+]
 # All test code, wherever it lives (project suite under tests/, smoke tests under
 # .rhiza/tests/, and their bundle copies under bundles/). This glob subsumes the
 # project suite; tests/**/*.py below adds project-suite-only allowances on top.

--- a/src/pyhrp/algos.py
+++ b/src/pyhrp/algos.py
@@ -160,9 +160,9 @@ def _allocate(root: Cluster, assets: list[str], combine: Callable[[Cluster], Clu
 def _children(cluster: Cluster) -> tuple[Cluster, Cluster]:
     """Return the validated left and right children of a non-leaf cluster."""
     if not isinstance(cluster.left, Cluster):
-        raise TypeError("Expected left child to be a Cluster")  # noqa: TRY003
+        raise TypeError("Expected left child to be a Cluster")
     if not isinstance(cluster.right, Cluster):
-        raise TypeError("Expected right child to be a Cluster")  # noqa: TRY003
+        raise TypeError("Expected right child to be a Cluster")
     return cluster.left, cluster.right
 
 

--- a/src/pyhrp/cluster.py
+++ b/src/pyhrp/cluster.py
@@ -142,11 +142,11 @@ class Cluster(Node[int]):
             return [self]
         else:
             if self.left is None:
-                raise ValueError("Expected left child to exist for non-leaf cluster")  # noqa: TRY003
+                raise ValueError("Expected left child to exist for non-leaf cluster")
             if self.right is None:
-                raise ValueError("Expected right child to exist for non-leaf cluster")  # noqa: TRY003
+                raise ValueError("Expected right child to exist for non-leaf cluster")
             if not isinstance(self.left, Cluster):
-                raise TypeError(f"Expected left child to be a Cluster for node {self.value}")  # noqa: TRY003
+                raise TypeError(f"Expected left child to be a Cluster for node {self.value}")
             if not isinstance(self.right, Cluster):
-                raise TypeError(f"Expected right child to be a Cluster for node {self.value}")  # noqa: TRY003
+                raise TypeError(f"Expected right child to be a Cluster for node {self.value}")
             return self.left.leaves + self.right.leaves

--- a/src/pyhrp/hrp.py
+++ b/src/pyhrp/hrp.py
@@ -168,13 +168,13 @@ class Dendrogram:
         """
         if self.distance is not None:
             if not isinstance(self.distance, pl.DataFrame):
-                raise TypeError("distance must be a polars DataFrame.")  # noqa: TRY003
+                raise TypeError("distance must be a polars DataFrame.")
 
             if self.distance.columns != list(self.assets):
-                raise ValueError("Distance matrix index/columns must align with assets.")  # noqa: TRY003
+                raise ValueError("Distance matrix index/columns must align with assets.")
 
         if len(self.root.leaves) != len(self.assets):
-            raise ValueError("Number of leaves does not match number of assets.")  # noqa: TRY003
+            raise ValueError("Number of leaves does not match number of assets.")
 
     def plot(self, **kwargs: object) -> go.Figure:
         """Build and return a plotly dendrogram figure.
@@ -209,7 +209,7 @@ def _compute_distance_matrix(corr: pl.DataFrame) -> pl.DataFrame:
 def _bisect_tree(ids: list[int], next_id: int) -> tuple[Cluster, int]:
     """Build tree by recursive bisection."""
     if not ids:
-        raise ValueError("ids must contain at least one node id.")  # noqa: TRY003
+        raise ValueError("ids must contain at least one node id.")
     if len(ids) == 1:
         return Cluster(value=ids[0]), next_id
 
@@ -226,9 +226,9 @@ def _get_linkage(node: Cluster) -> list[list[float]]:
     links_list: list[list[float]] = []
     if node.left is not None and node.right is not None:
         if not isinstance(node.left, Cluster):
-            raise TypeError("Expected left child to be a Cluster")  # noqa: TRY003  # pragma: no cover
+            raise TypeError("Expected left child to be a Cluster")  # pragma: no cover
         if not isinstance(node.right, Cluster):
-            raise TypeError("Expected right child to be a Cluster")  # noqa: TRY003  # pragma: no cover
+            raise TypeError("Expected right child to be a Cluster")  # pragma: no cover
         links_list.extend(_get_linkage(node.left))
         links_list.extend(_get_linkage(node.right))
         links_list.append(
@@ -277,7 +277,7 @@ def build_tree(
         2
     """
     if not isinstance(cor, pl.DataFrame):
-        raise TypeError("Correlation matrix must be a polars DataFrame.")  # noqa: TRY003
+        raise TypeError("Correlation matrix must be a polars DataFrame.")
     if len(cor.columns) < 2:
         msg = "Correlation matrix must contain at least two assets."
         raise ValueError(msg)


### PR DESCRIPTION
Closes #718

## What changed
- Added a `src/pyhrp/*.py` entry to `[lint.per-file-ignores]` in `ruff.toml` ignoring `TRY003`, mirroring the existing `.rhiza/utils/*.py` policy and the project's stated stance (`# EM: literal exception messages are fine at our scale`).
- Removed all **13** scattered `# noqa: TRY003` inline comments from `src/pyhrp/{algos,cluster,hrp}.py`. The two `# pragma: no cover` markers on the defensive guards in `hrp.py` are preserved.

No runtime or behavior change — config + comment cleanup only.

## Confirming gates (on branch)
- `make fmt` — pass (ruff clean: no unused-noqa, TRY003 now suppressed via config)
- `make test` — 114 passed, 100% coverage
- `make suppression-audit` — Grade **A** (was C); density 1.33 → 0.20 per 100 LOC

🤖 Generated with [Claude Code](https://claude.com/claude-code)