### PR TITLE
chore: update rhiza to v1.1.1

### DIFF
--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.1.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.1.1
     secrets: inherit

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.1.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.1.1
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.1.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.1.1
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.1.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.1.1
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/.github/workflows/rhiza_fuzzing.yml
+++ b/.github/workflows/rhiza_fuzzing.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   fuzzing:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.1.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.1.1
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.1.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.1.1
     secrets: inherit

--- a/.github/workflows/rhiza_mutation.yml
+++ b/.github/workflows/rhiza_mutation.yml
@@ -42,7 +42,7 @@ jobs:
     # this repo sets the `MUTATION_ENABLED` variable to 'true'. Gating here in
     # the caller keeps it optional regardless of the pinned reusable workflow.
     if: ${{ vars.MUTATION_ENABLED == 'true' }}
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.1.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.1.1
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -221,7 +221,7 @@ jobs:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.1.0
+        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.1.1
         with:
           token: ${{ secrets.GH_PAT }}
 

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.1.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.1.1
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/.github/workflows/rhiza_sync.yml
+++ b/.github/workflows/rhiza_sync.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   sync:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v1.1.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v1.1.1
     with:
       direct: ${{ github.event_name == 'push' }}
       create-pr: ${{ github.event_name != 'push' && (github.event_name == 'schedule' || inputs.create-pr == true) }}

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.1.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.1.1
     secrets: inherit

--- a/.rhiza/make.d/test.mk
+++ b/.rhiza/make.d/test.mk
@@ -92,17 +92,17 @@ typecheck: install ## run ty and/or mypy type checking (TYPECHECKER=ty|mypy|both
 	case "${TYPECHECKER}" in \
 	  ty) \
 	    printf "${BLUE}[INFO] Running ty type checking in:$${typecheck_paths}${RESET}\n"; \
-	    ${UV_BIN} run ty check $${typecheck_paths} \
+	    ${UV_BIN} run --with ty ty check $${typecheck_paths} \
 	    ;; \
 	  mypy) \
 	    printf "${BLUE}[INFO] Running mypy strict type checking in:$${typecheck_paths}${RESET}\n"; \
-	    ${UV_BIN} run mypy --strict $${typecheck_paths} \
+	    ${UV_BIN} run --with mypy mypy --strict $${typecheck_paths} \
 	    ;; \
 	  both) \
 	    printf "${BLUE}[INFO] Running ty type checking in:$${typecheck_paths}${RESET}\n"; \
-	    ${UV_BIN} run ty check $${typecheck_paths} && \
+	    ${UV_BIN} run --with ty ty check $${typecheck_paths} && \
 	    printf "${BLUE}[INFO] Running mypy strict type checking in:$${typecheck_paths}${RESET}\n"; \
-	    ${UV_BIN} run mypy --strict $${typecheck_paths} \
+	    ${UV_BIN} run --with mypy mypy --strict $${typecheck_paths} \
 	    ;; \
 	  *) \
 	    printf "${RED}[ERROR] Invalid TYPECHECKER='${TYPECHECKER}' (expected: ty, mypy, or both)${RESET}\n"; \

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,7 +1,7 @@
-sha: 94214b12ebb2747d52de8ab9e3601579495757f4
+sha: cc162bbe38291955e0aa5f3418c1bcfd10fbba24
 repo: jebel-quant/rhiza
 host: github
-ref: v1.1.0
+ref: v1.1.1
 include: []
 exclude: []
 templates:
@@ -83,5 +83,5 @@ files:
 - ruff.toml
 profiles:
 - github-project
-synced_at: '2026-07-09T06:23:41Z'
+synced_at: '2026-07-09T12:08:56Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 template-repository: "jebel-quant/rhiza"
-template-branch: "v1.1.0"
+template-branch: "v1.1.1"
 
 profiles:
   - github-project


### PR DESCRIPTION
## Summary
- Bumps the template `template-branch` to `v1.1.1` in `.rhiza/template.yml` (was `v1.1.0`)
- Platform profile: `github-project` (unchanged — origin is on github.com, already matched)
- Runs `make sync` to apply upstream template changes; sync applied cleanly, no conflicts or `.rej` files
- `.rhiza/.rhiza-version` (tool version `0.18.0`) left untouched — decoupled from the template ref
- Sync touched 13 files: 11 `.github/workflows/*`, `.rhiza/make.d/test.mk`, `.rhiza/template.lock`

## Quality gates

| Gate | Result | Evidence |
|---|---|---|
| `make fmt` | ✅ PASS | All pre-commit hooks passed (ruff, markdownlint, bandit, actionlint, mypy, interrogate); no auto-format changes |
| `make typecheck` | ✅ PASS | `ty`: All checks passed; `mypy --strict`: no issues in 6 source files |
| `make docs-coverage` | ✅ PASS | interrogate: `RESULT: PASSED (minimum 100.0%, actual 100.0%)` |
| `make deptry` | ✅ PASS | `Success! No dependency issues found` (6 files) |
| `make security` | ✅ PASS | pip-audit: no vulnerabilities; bandit: clean over `src` |
| `make validate` | ✅ PASS | `✓ template.yml is valid`; 47 `.rhiza/tests` passed |
| `make test` | ✅ PASS | `114 passed`; coverage `100.00%` (gate ≥90%) |

**7/7 gates PASS.**

## Scorecard

Scoped to locally-owned items (`src/`, `tests/`, `pyproject.toml`, `.rhiza/template.yml`); Rhiza-managed files noted as upstream where relevant.

| Subcategory | Score | Justification |
|---|---|---|
| Linting / style | **10** | Every ruff/markdownlint/bandit hook green; no format drift |
| Type safety | **10** | ty + mypy `--strict` both clean over all 6 modules |
| Docstring / API-doc coverage | **10** | interrogate 100% (254/254 objects) |
| Test pass rate | **10** | 114/114 passed |
| Test coverage & depth | **10** | 100% on all `src/`; depth strong — property (hypothesis), stress (500/1000 assets), fuzz, benchmark, validation-edge suites |
| Dependency & security hygiene | **10** | deptry clean; pip-audit clean; bandit clean |
| Template fidelity | **10** | `make validate` passes; sync applied cleanly, no drift/`.rej` |
| Code complexity | **10** | radon avg **A (2.62)**; worst block A(5); no C-or-worse; every module MI grade **A** |
| Overall architecture | **10** | Acyclic layered DAG `treelib←cluster←algos←hrp`; plotly lazily decoupled; no cycles/god-modules |
| Test design quality | **10** | Tests assert behaviour (weights sum to one, variance reduction, raises-on-bad-input), not implementation mirroring; no brittle internal mocking |

**Overall: 10 / 10.**

### Highest-leverage improvement
None required — the repo is at the ceiling of the Rhiza rubric. (Future-proofing only, and Rhiza-owned/upstream: `COVERAGE_FAIL_UNDER` is 90% while actual coverage is 100%; raising the floor would lock in the margin, but that config is template-managed and out of scope here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated multiple automation workflows and templates to use the latest supported release version.
  * Refreshed the type-checking command flow to run tools through the project environment for more consistent local and CI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->