### PR TITLE
Align allocator contract, de-duplicate scaffolding, add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,86 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+pyhrp is a recursive implementation of Hierarchical Risk Parity (HRP) by Marcos Lopez de Prado,
+built on top of `scipy.cluster.hierarchy`. Given a price/return frame it builds a clustering tree
+from asset co-movement and allocates risk recursively along that tree, avoiding explicit return
+forecasting.
+
+The public API is re-exported from `pyhrp` (`src/pyhrp/__init__.py`).
+
+## Package layout
+
+The `src/pyhrp/` package is split into small, focused modules:
+
+| Module | Responsibility |
+| --- | --- |
+| `hrp.py` | High-level entry points. Turns a price/return frame into a weighted tree: `compute_cov`/`compute_corr` build the matrices, `build_tree` produces the `Dendrogram`, and `hrp`/`schur_hrp` run the full pipeline end to end. |
+| `algos.py` | The allocation algorithms that size a cluster tree: `risk_parity` (recursive HRP), `schur_risk_parity` (Schur Complementary Allocation), and `one_over_n` (equal weight). |
+| `cluster.py` | Core data structures — `Cluster` (a node in the hierarchical tree) and `Portfolio` (an asset-to-weight mapping with analysis/plot helpers). |
+| `covariance.py` | `compute_cov`/`compute_corr` helpers that turn a returns frame into covariance/correlation matrices. |
+| `dendrogram.py` | `build_tree` plus the `Dendrogram` container (the clustering result and its plotting/ordering helpers). |
+| `treelib.py` | A minimal generic binary-tree `Node`, kept in-house to avoid a `binarytree` dependency. |
+| `plot.py` | Plotly dendrogram rendering (`plot_dendrogram`), kept separate so the optional plotting dependency does not couple the algorithm modules. |
+| `__init__.py` | Public API surface — re-exports the functions and classes above and exposes `__version__`. |
+
+## Module layering
+
+Dependencies flow in one direction, from the generic tree up to the public surface:
+
+```text
+treelib  ->  cluster  ->  {algos, dendrogram}  ->  hrp  ->  __init__
+```
+
+- `treelib` depends on nothing internal; `cluster.Cluster` subclasses `treelib.Node`.
+- `algos` and `dendrogram` build on `cluster` (and `covariance`); neither imports `hrp`.
+- `hrp` composes `covariance` + `dendrogram` + `algos` into the end-to-end pipeline.
+- `plot`/Plotly is imported lazily (inside `Dendrogram.plot`) so importing the allocation
+  core stays plotly-free.
+
+### Allocator contract
+
+The three allocators in `algos.py` share one contract: each takes a `Cluster` tree (`root`)
+plus the asset names, and never mutates the tree — weights are rebuilt from scratch, so every
+allocator is idempotent and a tree can be reused. `risk_parity` and `schur_risk_parity` share the
+`_allocate_with` scaffolding and return the fully weighted root `Cluster`. `one_over_n`
+intentionally differs only in its output: it is a generator yielding the equal-weight portfolio
+one tree level at a time (`Dendrogram.one_over_n()` is the container-level convenience wrapper).
+
+## Development commands
+
+```bash
+make install    # Install uv, create .venv, install dependencies
+make test       # Run pytest with coverage (fails under the coverage gate)
+make fmt        # Run the pre-commit hooks: ruff format + check, markdownlint
+make typecheck  # Run mypy in strict mode over src/
+make book       # Build the Marimo/mkdocs documentation
+```
+
+## Key invariants
+
+CI enforces these gates — keep them green when changing code:
+
+- **100% test coverage** — `make test` fails below the coverage threshold; cover every new branch.
+- **100% docstring coverage** — `interrogate --fail-under 100`; every public module, class,
+  and function needs a docstring (Google style).
+- **Strict typing** — `mypy` runs in strict mode over `src/`; annotate all public signatures.
+- **1:1 test/source layout** — each `src/pyhrp/<mod>.py` has a mirrored `tests/pyhrp/test_<mod>.py`.
+- **Linting/formatting** — `ruff` (line length 120, Google-style docstrings) plus `markdownlint`.
+
+## Tech stack
+
+- **Package manager**: uv
+- **Core dependencies**: NumPy, polars, scipy (Plotly is optional, for plotting only)
+- **Testing**: pytest with coverage and Hypothesis property tests
+- **Docs**: Marimo notebooks (`book/marimo/`) rendered via mkdocs
+- **Rhiza**: `.rhiza/` holds template-managed config — do not edit it directly
+
+## Workflow
+
+1. Run `make install` to set up the environment.
+2. Write code in `src/pyhrp/` and mirrored tests in `tests/pyhrp/`.
+3. Run `make test` to verify changes at 100% coverage.
+4. Run `make typecheck` and `make fmt` before committing.

--- a/book/marimo/1_over_N.py
+++ b/book/marimo/1_over_N.py
@@ -66,9 +66,7 @@ def _(cor):
 
 @app.cell
 def _(dendrogram) -> None:
-    from pyhrp.algos import one_over_n
-
-    for level, portfolio in one_over_n(dendrogram):
+    for level, portfolio in dendrogram.one_over_n():
         print(f"Level: {level}")
         portfolio.plot(names=dendrogram.names).show()
     return

--- a/src/pyhrp/algos.py
+++ b/src/pyhrp/algos.py
@@ -4,21 +4,29 @@ This module implements various portfolio optimization algorithms:
 - risk_parity: The main hierarchical risk parity algorithm
 - schur_risk_parity: Schur Complementary Allocation (Cotton, arXiv:2411.05807)
 - one_over_n: A simple equal-weight allocation strategy
+
+Allocator contract
+------------------
+All three allocators take the same inputs — a ``Cluster`` tree (``root``) plus
+the asset names — and never mutate the tree they are given: weights are always
+rebuilt from scratch, so every allocator is idempotent and a tree can be reused.
+``risk_parity`` and ``schur_risk_parity`` share the recursive ``_allocate_with``
+scaffolding and each return the fully weighted root ``Cluster``. ``one_over_n``
+intentionally differs in its *output*: it is a generator that yields the
+equal-weight portfolio one tree level at a time (see its docstring), because its
+purpose is to expose the allocation as it deepens rather than a single final
+result.
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable, Generator
 from copy import deepcopy
-from typing import TYPE_CHECKING
 
 import numpy as np
 import polars as pl
 
 from .cluster import Cluster, Portfolio
-
-if TYPE_CHECKING:
-    from .dendrogram import Dendrogram
 
 __all__ = ["one_over_n", "risk_parity", "schur_risk_parity"]
 
@@ -52,17 +60,15 @@ def risk_parity(root: Cluster, cov: pl.DataFrame) -> Cluster:
         >>> round(cluster.portfolio["B"], 1)
         0.8
     """
-    cov_np = cov.to_numpy()
-    index = {name: i for i, name in enumerate(cov.columns)}
 
-    def combine(cluster: Cluster) -> Cluster:
-        """Combine the child portfolios of a cluster via inverse-variance split."""
-        left, right = _children(cluster)
-        v_left = _block_variance(left.portfolio, cov_np, index)
-        v_right = _block_variance(right.portfolio, cov_np, index)
-        return _split(cluster, v_left, v_right)
+    def node_variances(left: Cluster, right: Cluster, cov_np: np.ndarray, index: dict[str, int]) -> tuple[float, float]:
+        """Plain block variance of each child sub-portfolio."""
+        return (
+            _block_variance(left.portfolio, cov_np, index),
+            _block_variance(right.portfolio, cov_np, index),
+        )
 
-    return _allocate(root, cov.columns, combine)
+    return _allocate_with(root, cov, node_variances)
 
 
 def schur_risk_parity(root: Cluster, cov: pl.DataFrame, gamma: float = 0.5) -> Cluster:
@@ -103,13 +109,8 @@ def schur_risk_parity(root: Cluster, cov: pl.DataFrame, gamma: float = 0.5) -> C
         msg = f"gamma must be in [0, 1], got {gamma}"
         raise ValueError(msg)
 
-    cov_np = cov.to_numpy()
-    index = {name: i for i, name in enumerate(cov.columns)}
-
-    def combine(cluster: Cluster) -> Cluster:
-        """Combine the child portfolios of a cluster via a Schur-augmented split."""
-        left, right = _children(cluster)
-
+    def node_variances(left: Cluster, right: Cluster, cov_np: np.ndarray, index: dict[str, int]) -> tuple[float, float]:
+        """Schur-augmented block variance of each child, conditioned on the other."""
         li = [index[a] for a in left.portfolio.assets]
         ri = [index[a] for a in right.portfolio.assets]
 
@@ -126,6 +127,43 @@ def schur_risk_parity(root: Cluster, cov: pl.DataFrame, gamma: float = 0.5) -> C
 
         v_left = float(w_left @ a_aug @ w_left)
         v_right = float(w_right @ d_aug @ w_right)
+        return v_left, v_right
+
+    return _allocate_with(root, cov, node_variances)
+
+
+# Given a node's two children (plus the precomputed covariance array and the
+# column->row index), return the (v_left, v_right) risk pair used to split it.
+NodeVariances = Callable[[Cluster, Cluster, np.ndarray, dict[str, int]], tuple[float, float]]
+
+
+def _allocate_with(root: Cluster, cov: pl.DataFrame, node_variances: NodeVariances) -> Cluster:
+    """Shared scaffolding for the recursive risk-based allocators.
+
+    Builds the numpy covariance array and column index once, then walks the tree
+    bottom-up, splitting each node's weight between its children inversely to the
+    ``(v_left, v_right)`` pair supplied by ``node_variances``. The only thing that
+    distinguishes ``risk_parity`` from ``schur_risk_parity`` is that per-node
+    variance rule; everything else — the ``cov``/``index`` setup, the combine
+    wrapper, and the rebuild-from-scratch traversal — lives here.
+
+    Args:
+        root (Cluster): The root node of the cluster tree.
+        cov (pl.DataFrame): Covariance matrix of asset returns.
+        node_variances (NodeVariances): Per-node rule mapping a node's left/right
+            children (and the precomputed covariance array and column index) to
+            the ``(v_left, v_right)`` risk pair used to split that node.
+
+    Returns:
+        Cluster: The root node with portfolio weights assigned.
+    """
+    cov_np = cov.to_numpy()
+    index = {name: i for i, name in enumerate(cov.columns)}
+
+    def combine(cluster: Cluster) -> Cluster:
+        """Combine the child portfolios of a cluster via an inverse-variance split."""
+        left, right = _children(cluster)
+        v_left, v_right = node_variances(left, right, cov_np, index)
         return _split(cluster, v_left, v_right)
 
     return _allocate(root, cov.columns, combine)
@@ -215,20 +253,30 @@ def _solve(m: np.ndarray, b: np.ndarray) -> np.ndarray:
         return np.asarray(np.linalg.lstsq(m, b, rcond=None)[0])
 
 
-def one_over_n(dendrogram: Dendrogram) -> Generator[tuple[int, Portfolio]]:
-    """Generate portfolios using the 1/N (equal weight) strategy at each tree level.
+def one_over_n(root: Cluster, assets: list[str]) -> Generator[tuple[int, Portfolio]]:
+    """Generate 1/N (equal-weight) portfolios one tree level at a time.
 
-    This function implements a hierarchical 1/N strategy where weights are
-    distributed equally among assets within each cluster at each level of the tree.
-    The weight assigned to each cluster decreases by half at each level.
+    This implements a hierarchical 1/N strategy where weights are distributed
+    equally among the leaves of each cluster, and the weight budget halves at
+    each successive level of the tree.
+
+    Unlike :func:`risk_parity` and :func:`schur_risk_parity` — which rebuild a
+    single final allocation and return the root ``Cluster`` — this allocator is
+    intentionally a **generator**: its purpose is to expose the equal-weight
+    allocation as the tree deepens, yielding one portfolio per level. It shares
+    the sibling input contract (a ``Cluster`` tree plus the asset names) and, like
+    them, does not mutate the tree: weights accumulate in a local buffer, so a
+    leaf that terminates at a shallow level keeps its weight in the deeper levels
+    (each yielded portfolio is therefore a complete allocation over all assets),
+    and re-running on the same tree yields an identical sequence.
 
     Args:
-        dendrogram: A dendrogram object containing the hierarchical clustering tree
-                   and the list of assets
+        root (Cluster): The root node of the cluster tree.
+        assets (list[str]): Asset names; a leaf's value indexes into this list.
 
     Yields:
-        tuple[int, Portfolio]: A tuple containing the level number and the portfolio
-                              at that level
+        tuple[int, Portfolio]: The level number and the (cumulative) equal-weight
+        portfolio at that level.
 
     Examples:
         >>> import polars as pl
@@ -236,12 +284,12 @@ def one_over_n(dendrogram: Dendrogram) -> Generator[tuple[int, Portfolio]]:
         >>> from pyhrp.algos import one_over_n
         >>> cor = pl.DataFrame({"A": [1.0, 0.3], "B": [0.3, 1.0]})
         >>> dg = build_tree(cor, method="ward")
-        >>> levels = list(one_over_n(dg))
+        >>> levels = list(one_over_n(dg.root, dg.assets))
         >>> len(levels) > 0
         True
     """
-    root = dendrogram.root
-    assets = dendrogram.assets
+    # Accumulate into a local buffer so the input tree is never mutated.
+    portfolio = Portfolio()
 
     # Initial weight to distribute
     w: float = 1.0
@@ -251,10 +299,10 @@ def one_over_n(dendrogram: Dendrogram) -> Generator[tuple[int, Portfolio]]:
         for node in level:
             # Distribute weight equally among all leaves in this node
             for leaf in node.leaves:
-                root.portfolio[assets[leaf.value]] = w / node.leaf_count
+                portfolio[assets[leaf.value]] = w / node.leaf_count
 
         # Reduce weight for the next level
         w *= 0.5
 
         # Yield the current level number and a deep copy of the portfolio
-        yield n, deepcopy(root.portfolio)
+        yield n, deepcopy(portfolio)

--- a/src/pyhrp/dendrogram.py
+++ b/src/pyhrp/dendrogram.py
@@ -8,6 +8,7 @@ allocation entry points and stores it in a :class:`Dendrogram`:
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
@@ -16,7 +17,7 @@ import polars as pl
 import scipy.cluster.hierarchy as sch
 import scipy.spatial.distance as ssd
 
-from .cluster import Cluster
+from .cluster import Cluster, Portfolio
 
 if TYPE_CHECKING:
     import plotly.graph_objects as go
@@ -71,6 +72,21 @@ class Dendrogram:
         from .plot import plot_dendrogram
 
         return plot_dendrogram(self, **kwargs)
+
+    def one_over_n(self) -> Generator[tuple[int, Portfolio]]:
+        """Yield the hierarchical 1/N portfolios level by level for this tree.
+
+        Container-level convenience wrapper around :func:`pyhrp.algos.one_over_n`;
+        the allocation core is imported lazily so importing the dendrogram module
+        does not pull in the allocation module.
+
+        Yields:
+            tuple[int, Portfolio]: The level number and the equal-weight portfolio
+            at that level.
+        """
+        from .algos import one_over_n
+
+        yield from one_over_n(self.root, self.assets)
 
     @property
     def ids(self) -> list[int]:

--- a/tests/pyhrp/test_algos.py
+++ b/tests/pyhrp/test_algos.py
@@ -221,7 +221,7 @@ def test_one_over_n() -> None:
     dendrogram = Dendrogram(root=root, assets=[a, b, c])
 
     # Collect portfolios from one_over_n algorithm
-    portfolios: list[tuple[int, Portfolio]] = list(one_over_n(dendrogram))
+    portfolios: list[tuple[int, Portfolio]] = list(one_over_n(dendrogram.root, dendrogram.assets))
 
     # Check that we get the expected number of levels
     assert len(portfolios) == len(root.levels)
@@ -259,7 +259,7 @@ def test_one_over_n_large(returns: DataFrame) -> None:
     cor = compute_corr(returns)
     dendrogram = build_tree(cor=cor, method="ward")
 
-    portfolios: list[tuple[int, Portfolio]] = list(one_over_n(dendrogram))
+    portfolios: list[tuple[int, Portfolio]] = list(one_over_n(dendrogram.root, dendrogram.assets))
 
     assert len(portfolios) > 0
     assert len(portfolios) == len(dendrogram.root.levels)
@@ -269,6 +269,23 @@ def test_one_over_n_large(returns: DataFrame) -> None:
         assert set(portfolio.assets) == set(dendrogram.assets)
         for weight in portfolio.weights.values():
             assert weight > 0
+
+
+def test_one_over_n_does_not_mutate_tree() -> None:
+    """one_over_n rebuilds into a local buffer and leaves the input tree untouched."""
+    root = Cluster(10)
+    root.left = Cluster(11)
+    root.right = Cluster(0)
+    root.left.left = Cluster(1)
+    root.left.right = Cluster(2)
+    dendrogram = Dendrogram(root=root, assets=["A", "B", "C"])
+
+    # Exhaust the generator, then confirm the root's own portfolio is still empty
+    # and a second run yields an identical sequence (observable idempotency).
+    first = [(lvl, dict(p.weights)) for lvl, p in one_over_n(dendrogram.root, dendrogram.assets)]
+    assert dendrogram.root.portfolio.weights == {}
+    second = [(lvl, dict(p.weights)) for lvl, p in one_over_n(dendrogram.root, dendrogram.assets)]
+    assert first == second
 
 
 def test_solve_singular_falls_back_to_lstsq() -> None:

--- a/tests/pyhrp/test_dendrogram.py
+++ b/tests/pyhrp/test_dendrogram.py
@@ -489,3 +489,17 @@ def test_build_tree_depth_one_bisection_two_assets() -> None:
 
     cluster = risk_parity(root=dendrogram.root, cov=cov)
     assert sum(cluster.portfolio.weights.values()) == pytest.approx(1.0)
+
+
+def test_dendrogram_one_over_n_wrapper_matches_function() -> None:
+    """Dendrogram.one_over_n delegates to algos.one_over_n on its own tree/assets."""
+    from pyhrp.algos import one_over_n
+
+    root = Cluster(10, left=Cluster(11, left=Cluster(1), right=Cluster(2)), right=Cluster(0))
+    dendrogram = Dendrogram(root=root, assets=["A", "B", "C"])
+
+    via_wrapper = [(lvl, dict(p.weights)) for lvl, p in dendrogram.one_over_n()]
+    via_function = [(lvl, dict(p.weights)) for lvl, p in one_over_n(dendrogram.root, dendrogram.assets)]
+
+    assert via_wrapper == via_function
+    assert sum(via_wrapper[0][1].values()) == pytest.approx(1.0)


### PR DESCRIPTION
Addresses three open scorecard issues in `algos.py` and the docs set.

## #743 — Reduce duplicated allocation scaffolding
Factored the shared `cov`/`index`/`combine`/`_allocate` setup out of `risk_parity` and `schur_risk_parity` into one `_allocate_with(root, cov, node_variances)` helper. Each public algorithm now supplies only its per-node variance rule; public signatures and docstring examples are unchanged.

## #744 — Align `one_over_n` with the risk_parity/schur contract
- Takes `(root: Cluster, assets)` like its siblings instead of a whole `Dendrogram` (no longer coupled to the container).
- Accumulates weights in a local buffer, so the input tree is **never mutated** — restoring idempotency.
- The one intentional divergence (it stays a generator yielding a level-by-level progression) is now documented in the module and function docstrings.
- Added `Dendrogram.one_over_n()` as the thin container-level convenience wrapper (lazy import).

## #745 — Add `CLAUDE.md`
Package layout, module layering (`treelib → cluster → {algos, dendrogram} → hrp → __init__`), the allocator contract, the make workflow, and the coverage/docstring/typing/test-layout gates.

## Verification
- `make test`: 112 passed, **100% coverage**
- mypy strict, ruff, interrogate (100%), markdownlint — all clean

Closes #743
Closes #744
Closes #745

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a convenient `Dendrogram.one_over_n()` method for generating hierarchical equal-weight portfolios.
  * Portfolio results are generated consistently across tree levels without modifying the source dendrogram.
  * Updated the example notebook to use the new interface.

* **Bug Fixes**
  * Improved repeatability and consistency when generating 1/N portfolio allocations.

* **Documentation**
  * Added contributor guidance covering project structure, development workflows, quality checks, and contribution practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->