### PR TITLE
fix: enforce the documented 100% coverage invariant and de-duplicate child validation

### DIFF
--- a/.rhiza/.env
+++ b/.rhiza/.env
@@ -11,3 +11,7 @@
 MARIMO_FOLDER=docs/notebooks
 SOURCE_FOLDER=src
 RHIZA_CI_OS_MATRIX=["ubuntu-latest","macos-latest","windows-latest"]
+# CLAUDE.md documents 100% coverage as a CI-enforced invariant. The rhiza default
+# is 90, and `make test` passes --cov-fail-under on the pytest CLI, which wins over
+# [tool.coverage.report] in pyproject.toml — so the override has to live here.
+COVERAGE_FAIL_UNDER=100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,13 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/pyhrp"]
 
+[tool.coverage.run]
+branch = true
+
 [tool.coverage.report]
-fail_under = 90
+# CLAUDE.md states 100% coverage as a CI-enforced invariant; keep the gate and
+# the documented invariant identical so a regression cannot pass silently.
+fail_under = 100
 
 [tool.mypy]
 files = ["src"]

--- a/src/pyhrp/algos.py
+++ b/src/pyhrp/algos.py
@@ -162,7 +162,7 @@ def _allocate_with(root: Cluster, cov: pl.DataFrame, node_variances: NodeVarianc
 
     def combine(cluster: Cluster) -> Cluster:
         """Combine the child portfolios of a cluster via an inverse-variance split."""
-        left, right = _children(cluster)
+        left, right = cluster._child_clusters()
         v_left, v_right = node_variances(left, right, cov_np, index)
         return _split(cluster, v_left, v_right)
 
@@ -189,19 +189,10 @@ def _allocate(root: Cluster, assets: list[str], combine: Callable[[Cluster], Clu
         root.portfolio[assets[int(root.value)]] = 1.0
         return root
 
-    left, right = _children(root)
+    left, right = root._child_clusters()
     root.left = _allocate(left, assets, combine)
     root.right = _allocate(right, assets, combine)
     return combine(root)
-
-
-def _children(cluster: Cluster) -> tuple[Cluster, Cluster]:
-    """Return the validated left and right children of a non-leaf cluster."""
-    if not isinstance(cluster.left, Cluster):
-        raise TypeError("Expected left child to be a Cluster")
-    if not isinstance(cluster.right, Cluster):
-        raise TypeError("Expected right child to be a Cluster")
-    return cluster.left, cluster.right
 
 
 def _block_variance(portfolio: Portfolio, cov_np: np.ndarray, index: dict[str, int]) -> float:
@@ -227,7 +218,7 @@ def _split(cluster: Cluster, v_left: float, v_right: float) -> Cluster:
     Returns:
         Cluster: The parent cluster with portfolio weights assigned
     """
-    left, right = _children(cluster)
+    left, right = cluster._child_clusters()
     total = v_left + v_right
     alpha_left = v_right / total if total > 0 else 0.5
     alpha_right = 1.0 - alpha_left

--- a/src/pyhrp/dendrogram.py
+++ b/src/pyhrp/dendrogram.py
@@ -124,18 +124,15 @@ def _get_linkage(node: Cluster) -> list[list[float]]:
     """Convert tree structure back to linkage matrix format."""
     links_list: list[list[float]] = []
     if node.left is not None and node.right is not None:
-        if not isinstance(node.left, Cluster):
-            raise TypeError("Expected left child to be a Cluster")  # pragma: no cover
-        if not isinstance(node.right, Cluster):
-            raise TypeError("Expected right child to be a Cluster")  # pragma: no cover
-        links_list.extend(_get_linkage(node.left))
-        links_list.extend(_get_linkage(node.right))
+        left, right = node._child_clusters()
+        links_list.extend(_get_linkage(left))
+        links_list.extend(_get_linkage(right))
         links_list.append(
             [
-                float(node.left.value),
-                float(node.right.value),
+                float(left.value),
+                float(right.value),
                 float(node.size),
-                float(len(node.left.leaves) + len(node.right.leaves)),
+                float(len(left.leaves) + len(right.leaves)),
             ]
         )
     return links_list

--- a/tests/pyhrp/test_treelib.py
+++ b/tests/pyhrp/test_treelib.py
@@ -63,6 +63,19 @@ class TestNode:
         assert node2.leaves == [leaf4, leaf5]
         assert leaf3.leaves == [leaf3]
 
+    def test_leaves_half_populated(self) -> None:
+        """A non-leaf node with only one child descends into the child that exists."""
+        # A node with only a left child: the right branch is skipped
+        child = Node(value=2)
+        left_only = Node(value=1, left=child)
+        assert left_only.is_leaf is False
+        assert left_only.leaves == [child]
+
+        # A node with only a right child: the left branch is skipped
+        right_only = Node(value=1, right=child)
+        assert right_only.is_leaf is False
+        assert right_only.leaves == [child]
+
     def test_levels(self) -> None:
         """Test the levels property."""
         # Create a simple tree


### PR DESCRIPTION
Fixes the two findings from a `/rhiza:quality` run (full mode, template v1.3.3).

Closes #766
Closes #767

## Collapse child validation onto `Cluster._child_clusters` (#767)

The left/right child guards existed in **three** places, not the two the issue described:

| Location | Guards |
| --- | --- |
| `Cluster._child_clusters` (`cluster.py:155`) | missing child → `ValueError`, wrong type → `TypeError` |
| `algos._children` | wrong type → `TypeError` |
| inline in `dendrogram._get_linkage` | wrong type → `TypeError`, both `# pragma: no cover` |

`Cluster._child_clusters` is the most complete and sits in the lowest layer that both other callers already import, so it becomes the single implementation:

- `algos._children` is deleted; its three call sites (`combine`, `_allocate`, `_split`) call `cluster._child_clusters()`.
- `dendrogram._get_linkage`'s inline guards are replaced with the same call.

This removes the two `# pragma: no cover` markers the duplicated copy needed — there are now **none left in `src/`**.

Behaviour is unchanged:

- The existing `pytest.raises(TypeError, match="Expected left child to be a Cluster")` assertions still hold, because `_child_clusters`' message (`"...for node {value}"`) is a superset of the matched prefix and `match=` uses `re.search`.
- `_get_linkage` keeps its surrounding `left is not None and right is not None` check, so a leaf still yields `[]` rather than raising, and only the `TypeError` path inside `_child_clusters` is reachable from there — exactly as before.
- `SLF` (private-member access) is deliberately disabled repo-wide in `ruff.toml`, so the cross-module `_child_clusters()` call is not a lint violation.

## Raise the coverage gate to 100% and enable branch coverage (#766)

`CLAUDE.md` lists as a key invariant:

> **100% test coverage** — `make test` fails below the coverage threshold; cover every new branch.

The gate was actually set at **90**. The repo happened to sit at 100%, so the documented invariant and the enforced gate agreed only by coincidence — a regression to 91% would have passed CI while the docs claimed it could not.

**Editing `pyproject.toml` alone does not fix this.** `.rhiza/make.d/python.mk:211` passes `--cov-fail-under=$(COVERAGE_FAIL_UNDER)` on the pytest CLI, and the CLI flag beats `[tool.coverage.report]`. With only the pyproject edit in place, the run still reported `Required test coverage of 90% reached`.

The effective knob is `COVERAGE_FAIL_UNDER ?= 90` at `python.mk:64`. Since `python.mk` is template-owned, the override goes in `.rhiza/.env` — the file that documents itself as "project-local environment overrides" and already carries this repo's custom `RHIZA_CI_OS_MATRIX` and `MARIMO_FOLDER`. `pyproject.toml` is updated too, so a bare `coverage report` agrees with the make gate rather than silently disagreeing.

`branch = true` is also enabled, which is what "cover every new branch" actually asks for. It immediately exposed two uncovered branches in `Node.leaves` — `treelib.py:65->67` and `67->70`, the half-populated-node paths where a non-leaf has only one child. Rather than drop branch coverage, these are now covered by `test_leaves_half_populated` in the mirrored test file.

```
Name                      Stmts   Miss Branch BrPart  Cover
src/pyhrp/treelib.py         59      0     24      0   100%
TOTAL                       338      0     78      0   100%
Required test coverage of 100% reached. Total coverage: 100.00%
```

## Verification

All gates re-run locally and green:

| Gate | Result |
| --- | --- |
| `make fmt` | PASS — 22 hooks, no rewrites |
| `make typecheck` | PASS — `ty` + `mypy --strict`, 8 files |
| `make docs-coverage` | PASS — 100.0% |
| `make deptry` | PASS |
| `make security` | PASS |
| `make rhiza-test` | PASS — 39 passed, doctests executed |
| `make test` | PASS — **114** passed, 100% statement **and** branch |
| Test-layout parity | PASS — tests mirror sources 1:1 |

Complexity moved slightly with the de-duplication: average CC 2.53 → **2.48** (47 → 46 blocks), `algos.py` 308 → 296 lines. All modules remain maintainability grade A.

## Note for a future template bump

`make deptry` now warns it is deprecated in favour of `make deps`. That target is template-owned, so it is out of scope here, but it will eventually disappear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
