### PR TITLE
Fix both /rhiza:quality findings: public compute_returns and Schur docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,10 +17,10 @@ The `src/pyhrp/` package is split into small, focused modules:
 
 | Module | Responsibility |
 | --- | --- |
-| `hrp.py` | High-level entry points. Turns a price/return frame into a weighted tree: `compute_cov`/`compute_corr` build the matrices, `build_tree` produces the `Dendrogram`, and `hrp`/`schur_hrp` run the full pipeline end to end. |
+| `hrp.py` | High-level entry points. Turns a price/return frame into a weighted tree: `compute_returns`/`compute_cov`/`compute_corr` build the matrices, `build_tree` produces the `Dendrogram`, and `hrp`/`schur_hrp` run the full pipeline end to end. |
 | `algos.py` | The allocation algorithms that size a cluster tree: `risk_parity` (recursive HRP), `schur_risk_parity` (Schur Complementary Allocation), and `one_over_n` (equal weight). |
 | `cluster.py` | Core data structures — `Cluster` (a node in the hierarchical tree) and `Portfolio` (an asset-to-weight mapping with analysis/plot helpers). |
-| `covariance.py` | `compute_cov`/`compute_corr` helpers that turn a returns frame into covariance/correlation matrices. |
+| `covariance.py` | `compute_returns` turns a price frame into simple returns; `compute_cov`/`compute_corr` turn that returns frame into covariance/correlation matrices. |
 | `dendrogram.py` | `build_tree` plus the `Dendrogram` container (the clustering result and its plotting/ordering helpers). |
 | `treelib.py` | A minimal generic binary-tree `Node`, kept in-house to avoid a `binarytree` dependency. |
 | `plot.py` | Plotly dendrogram rendering (`plot_dendrogram`), kept separate so the optional plotting dependency does not couple the algorithm modules. |

--- a/README.md
+++ b/README.md
@@ -46,16 +46,11 @@ Here's a simple example
 
 ```python
 import polars as pl
-from pyhrp import build_tree, compute_cov, compute_corr, risk_parity
+from pyhrp import build_tree, compute_cov, compute_corr, compute_returns, risk_parity
 
 prices = pl.read_csv("tests/resources/stock_prices.csv", try_parse_dates=True).drop("date")
 
-returns = (
-    prices.select(pl.all().pct_change())
-    .filter(pl.any_horizontal(pl.all().is_not_null()))
-    .fill_null(0.0)
-    .fill_nan(0.0)
-)
+returns = compute_returns(prices)
 cov = compute_cov(returns)
 cor = compute_corr(returns)
 
@@ -76,6 +71,47 @@ correlation matrix, and the construction of the dendrogram.
 from pyhrp import hrp
 root = hrp(prices=prices, method="ward", bisection=False)
 
+```
+
+## Schur Complementary Allocation
+
+Plain HRP splits risk between two clusters using only the covariance *within*
+each cluster, discarding the cross-block terms. Schur Complementary Allocation
+(Peter Cotton, [arXiv:2411.05807](https://arxiv.org/abs/2411.05807)) augments each
+sub-block with that discarded information via a Schur complement before splitting,
+and `gamma` controls how much of it is put back:
+
+| `gamma` | Behaviour |
+| --- | --- |
+| `0.0` | No augmentation — identical to plain HRP, weight for weight. |
+| `0.5` | Default. Half the cross-block information is restored; a middle ground that keeps HRP's diversification while trimming portfolio variance. |
+| `1.0` | Full augmentation — recovers the global minimum-variance portfolio, but through the same recursive hierarchy rather than a single unconstrained solve. |
+
+Raising `gamma` trades HRP's robustness for lower in-sample variance, so it is the
+knob to reach for when the covariance estimate is trustworthy. Values outside
+`[0, 1]` raise `ValueError`. Use `schur_hrp` for the end-to-end pipeline, or
+`schur_risk_parity` to size a tree you already built.
+
+```python
+from pyhrp import schur_hrp
+
+conservative = schur_hrp(prices=prices, method="ward", gamma=0.0)
+balanced = schur_hrp(prices=prices, method="ward", gamma=0.5)
+min_variance = schur_hrp(prices=prices, method="ward", gamma=1.0)
+
+print("gamma=0 reproduces HRP:", conservative.portfolio.weights == root.portfolio.weights)
+print(
+    "variance falls as gamma rises:",
+    min_variance.portfolio.variance(cov)
+    < balanced.portfolio.variance(cov)
+    < conservative.portfolio.variance(cov),
+)
+
+```
+
+```result
+gamma=0 reproduces HRP: True
+variance falls as gamma rises: True
 ```
 
 ## Interpreting results
@@ -108,7 +144,7 @@ The `src/pyhrp/` package is split into small, focused modules:
 
 | Module | Responsibility |
 | --- | --- |
-| `hrp.py` | High-level entry points. Turns a price/return frame into a weighted tree: `compute_cov`/`compute_corr` build the matrices, `build_tree` produces the `Dendrogram`, and `hrp`/`schur_hrp` run the full pipeline end to end. |
+| `hrp.py` | High-level entry points. Turns a price/return frame into a weighted tree: `compute_returns`/`compute_cov`/`compute_corr` build the matrices, `build_tree` produces the `Dendrogram`, and `hrp`/`schur_hrp` run the full pipeline end to end. |
 | `algos.py` | The allocation algorithms that size a cluster tree: `risk_parity` (recursive HRP), `schur_risk_parity` (Schur Complementary Allocation), and `one_over_n` (equal weight). |
 | `cluster.py` | Core data structures — `Cluster` (a node in the hierarchical tree) and `Portfolio` (an asset-to-weight mapping with analysis/plot helpers). |
 | `treelib.py` | A minimal generic binary-tree `Node`, kept in-house to avoid a `binarytree` dependency. |

--- a/src/pyhrp/__init__.py
+++ b/src/pyhrp/__init__.py
@@ -9,7 +9,7 @@ import importlib.metadata
 
 from .algos import one_over_n, risk_parity, schur_risk_parity
 from .cluster import Cluster, Portfolio
-from .hrp import Dendrogram, build_tree, compute_corr, compute_cov, hrp, schur_hrp
+from .hrp import Dendrogram, build_tree, compute_corr, compute_cov, compute_returns, hrp, schur_hrp
 
 __version__ = importlib.metadata.version("pyhrp")
 
@@ -21,6 +21,7 @@ __all__ = [
     "build_tree",
     "compute_corr",
     "compute_cov",
+    "compute_returns",
     "hrp",
     "one_over_n",
     "risk_parity",

--- a/src/pyhrp/covariance.py
+++ b/src/pyhrp/covariance.py
@@ -2,9 +2,9 @@
 
 This module isolates the second-moment estimators used by the HRP allocation
 entry points:
+- compute_returns: Simple returns from a DataFrame of prices
 - compute_cov: Covariance matrix from a DataFrame of returns
 - compute_corr: Correlation matrix from a DataFrame of returns
-- _returns: Simple returns from a DataFrame of prices
 """
 
 from __future__ import annotations
@@ -12,7 +12,34 @@ from __future__ import annotations
 import numpy as np
 import polars as pl
 
-__all__ = ["compute_corr", "compute_cov"]
+__all__ = ["compute_corr", "compute_cov", "compute_returns"]
+
+
+def compute_returns(prices: pl.DataFrame) -> pl.DataFrame:
+    """Compute simple returns from prices.
+
+    Drops leading all-null rows produced by pct_change and fills remaining
+    nulls/NaNs (e.g. from missing prices) with zero returns.
+
+    Args:
+        prices (pl.DataFrame): Asset price time series (columns are assets, rows are dates)
+
+    Returns:
+        pl.DataFrame: Simple returns, one row shorter than ``prices``
+
+    Examples:
+        >>> import polars as pl
+        >>> from pyhrp.covariance import compute_returns
+        >>> prices = pl.DataFrame({"A": [100.0, 110.0, 99.0]})
+        >>> compute_returns(prices)["A"].to_list()
+        [0.1, -0.1]
+    """
+    return (
+        prices.select(pl.all().pct_change())
+        .filter(pl.any_horizontal(pl.all().is_not_null()))
+        .fill_null(0.0)
+        .fill_nan(0.0)
+    )
 
 
 def compute_cov(df: pl.DataFrame) -> pl.DataFrame:
@@ -27,17 +54,3 @@ def compute_corr(df: pl.DataFrame) -> pl.DataFrame:
     cols = df.columns
     corr = np.atleast_2d(np.corrcoef(df.to_numpy().T))
     return pl.DataFrame(dict(zip(cols, corr, strict=True)))
-
-
-def _returns(prices: pl.DataFrame) -> pl.DataFrame:
-    """Compute simple returns from prices.
-
-    Drops leading all-null rows produced by pct_change and fills remaining
-    nulls/NaNs (e.g. from missing prices) with zero returns.
-    """
-    return (
-        prices.select(pl.all().pct_change())
-        .filter(pl.any_horizontal(pl.all().is_not_null()))
-        .fill_null(0.0)
-        .fill_nan(0.0)
-    )

--- a/src/pyhrp/hrp.py
+++ b/src/pyhrp/hrp.py
@@ -5,6 +5,7 @@ supporting building blocks so the public ``pyhrp.hrp`` API is unchanged:
 - hrp: Compute HRP portfolio weights from prices
 - schur_hrp: Compute Schur Complementary Allocation weights from prices
 - build_tree: Build a hierarchical cluster tree (see :mod:`pyhrp.dendrogram`)
+- compute_returns: Simple returns from prices (see :mod:`pyhrp.covariance`)
 - compute_cov / compute_corr: Second-moment estimators (see :mod:`pyhrp.covariance`)
 - Dendrogram: Clustering result container (see :mod:`pyhrp.dendrogram`)
 """
@@ -17,10 +18,10 @@ import polars as pl
 
 from .algos import risk_parity, schur_risk_parity
 from .cluster import Cluster
-from .covariance import _returns, compute_corr, compute_cov
+from .covariance import compute_corr, compute_cov, compute_returns
 from .dendrogram import Dendrogram, build_tree
 
-__all__ = ["Dendrogram", "build_tree", "compute_corr", "compute_cov", "hrp", "schur_hrp"]
+__all__ = ["Dendrogram", "build_tree", "compute_corr", "compute_cov", "compute_returns", "hrp", "schur_hrp"]
 
 
 def hrp(
@@ -56,7 +57,7 @@ def hrp(
         >>> round(sum(root.portfolio.weights.values()), 6)
         1.0
     """
-    returns = _returns(prices)
+    returns = compute_returns(prices)
     cov = compute_cov(returns)
     cor = compute_corr(returns)
     node = node or build_tree(cor, method=method, bisection=bisection).root
@@ -98,7 +99,7 @@ def schur_hrp(
         >>> round(sum(root.portfolio.weights.values()), 6)
         1.0
     """
-    returns = _returns(prices)
+    returns = compute_returns(prices)
     cov = compute_cov(returns)
     cor = compute_corr(returns)
     node = node or build_tree(cor, method=method, bisection=bisection).root

--- a/tests/pyhrp/test_covariance.py
+++ b/tests/pyhrp/test_covariance.py
@@ -7,7 +7,27 @@ import polars as pl
 import pytest
 from polars import DataFrame
 
-from pyhrp.covariance import compute_corr, compute_cov
+from pyhrp.covariance import compute_corr, compute_cov, compute_returns
+
+
+def test_compute_returns_simple_returns() -> None:
+    """Simple returns are pct_change, one row shorter than the price frame."""
+    prices = pl.DataFrame({"A": [100.0, 110.0, 99.0], "B": [50.0, 55.0, 44.0]})
+    rets = compute_returns(prices)
+
+    assert rets.shape == (2, 2)
+    assert rets.columns == prices.columns
+    assert rets["A"].to_list() == pytest.approx([0.1, -0.1])
+    assert rets["B"].to_list() == pytest.approx([0.1, -0.2])
+
+
+def test_compute_returns_fills_missing_with_zero() -> None:
+    """Nulls and NaNs from missing or flat prices become zero returns, not holes."""
+    prices = pl.DataFrame({"A": [100.0, None, 110.0], "B": [0.0, 0.0, 50.0]})
+    rets = compute_returns(prices)
+
+    assert rets.null_count().to_numpy().sum() == 0
+    assert not np.isnan(rets.to_numpy()).any()
 
 
 def test_compute_cov_matrix_properties(returns: DataFrame) -> None:


### PR DESCRIPTION
Fixes the two findings from a full-mode `/rhiza:quality` run (template `v1.3.3`).
Both were filed first and are closed by this PR.

## Closes #770 — cross-module private import

`hrp.py` imported the private `_returns` from `covariance` — the only
underscore-prefixed cross-module import in `src/pyhrp/`. Every other edge in the
documented layering (`treelib -> cluster -> algos -> dendrogram -> hrp -> __init__`)
goes through a public name, so this understated a real part of `covariance`'s
contract with `hrp`.

Promoted to **`compute_returns`**, matching the `compute_cov`/`compute_corr`
convention already in the module rather than the bare `returns` the issue
suggested, and moved to the top of the file as the pipeline's first step. Behaviour
is unchanged. It gains an Args/Returns docstring plus a doctest, and is exported
from `covariance`, `hrp` and `pyhrp`.

It was already covered indirectly via the `hrp` tests; now that it is public
surface, `tests/pyhrp/test_covariance.py` covers it directly — the pct_change
arithmetic and the null/NaN fill.

## Closes #769 — Schur allocator undiscoverable from the README

`schur_hrp`/`schur_risk_parity` appeared only as a one-line row in the
package-layout table, while the co-equal `risk_parity` got a worked example and a
full linkage-method comparison. `gamma` shapes the allocation and raises
`ValueError` outside `[0, 1]`, but the front page gave no example and no guidance
on choosing it.

New `## Schur Complementary Allocation` section: a gamma table (0.0 / 0.5 / 1.0),
the robustness-vs-variance trade-off, and an executable example.

**Both claims in it were verified against the shipped dataset before being
written**, not paraphrased from the docstring:

- `gamma=0` reproduces plain HRP weight for weight — max abs diff `0.0`
- variance falls monotonically: `5.478e-5` → `5.467e-5` → `5.449e-5` for gamma 0 → 0.5 → 1

The example prints both facts and is backed by a ` ```result ` block, so
`.rhiza/tests/test_readme_validation.py` executes it and diffs the output. The
claims are gate-enforced rather than asserted, and will fail CI if they stop
holding.

Also: the first README example now calls `compute_returns(prices)` instead of
hand-inlining a copy of that exact transform — the duplication existed *because*
the helper was private, so it is the same defect as #770. Module tables in
`README.md` and `CLAUDE.md` updated to list the new function.

## Verification — full gate re-run

| Gate | Result |
| --- | --- |
| `make fmt` | PASS |
| `make typecheck` | PASS — ty + mypy --strict, 8 modules |
| `make docs-coverage` | PASS — 242/242, 100.0% |
| `make deptry` | PASS |
| `make security` | PASS |
| `make rhiza-test` | PASS — 39/39, README output matches |
| `make test` | PASS — **116** passed (was 114), coverage **100.00%** |
| Test-layout parity | PASS — tests mirror sources 1:1 |
| Doc examples / README fences | PASS — **46** examples (was 42), 0 violations |

No public API is removed — `compute_returns` is purely additive, since the old
name was private.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public `compute_returns` utility for calculating simple returns.
  * Return calculations now handle missing values consistently.
  * Added documentation and examples for return computation and Schur Complementary Allocation.

* **Documentation**
  * Updated package layout and usage examples to include `compute_returns`.
  * Documented `gamma` behavior, validation, and variance comparisons for Schur allocation.

* **Tests**
  * Added coverage for return values, output structure, and missing-value handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->