### PR TITLE
fix: hoist exception messages to satisfy TRY003 after rhiza v1.3.4

### DIFF
--- a/src/pyhrp/cluster.py
+++ b/src/pyhrp/cluster.py
@@ -160,11 +160,15 @@ class Cluster(Node[int]):
             TypeError: If either child is not a Cluster.
         """
         if self.left is None:
-            raise ValueError("Expected left child to exist for non-leaf cluster")
+            msg = "Expected left child to exist for non-leaf cluster"
+            raise ValueError(msg)
         if self.right is None:
-            raise ValueError("Expected right child to exist for non-leaf cluster")
+            msg = "Expected right child to exist for non-leaf cluster"
+            raise ValueError(msg)
         if not isinstance(self.left, Cluster):
-            raise TypeError(f"Expected left child to be a Cluster for node {self.value}")
+            msg = f"Expected left child to be a Cluster for node {self.value}"
+            raise TypeError(msg)
         if not isinstance(self.right, Cluster):
-            raise TypeError(f"Expected right child to be a Cluster for node {self.value}")
+            msg = f"Expected right child to be a Cluster for node {self.value}"
+            raise TypeError(msg)
         return self.left, self.right

--- a/src/pyhrp/dendrogram.py
+++ b/src/pyhrp/dendrogram.py
@@ -56,13 +56,16 @@ class Dendrogram:
         """
         if self.distance is not None:
             if not isinstance(self.distance, pl.DataFrame):
-                raise TypeError("distance must be a polars DataFrame.")
+                msg = "distance must be a polars DataFrame."
+                raise TypeError(msg)
 
             if self.distance.columns != list(self.assets):
-                raise ValueError("Distance matrix index/columns must align with assets.")
+                msg = "Distance matrix index/columns must align with assets."
+                raise ValueError(msg)
 
         if len(self.root.leaves) != len(self.assets):
-            raise ValueError("Number of leaves does not match number of assets.")
+            msg = "Number of leaves does not match number of assets."
+            raise ValueError(msg)
 
     def plot(self, **kwargs: object) -> go.Figure:
         """Build and return a plotly dendrogram figure.
@@ -108,7 +111,8 @@ def _compute_distance_matrix(corr: pl.DataFrame) -> pl.DataFrame:
 def _bisect_tree(ids: list[int], next_id: int) -> tuple[Cluster, int]:
     """Build tree by recursive bisection."""
     if not ids:
-        raise ValueError("ids must contain at least one node id.")
+        msg = "ids must contain at least one node id."
+        raise ValueError(msg)
     if len(ids) == 1:
         return Cluster(value=ids[0]), next_id
 
@@ -198,7 +202,8 @@ def _validate_correlation_matrix(cor: pl.DataFrame) -> None:
         ValueError: If it has fewer than two assets or contains non-finite values.
     """
     if not isinstance(cor, pl.DataFrame):
-        raise TypeError("Correlation matrix must be a polars DataFrame.")
+        msg = "Correlation matrix must be a polars DataFrame."
+        raise TypeError(msg)
     if len(cor.columns) < 2:
         msg = "Correlation matrix must contain at least two assets."
         raise ValueError(msg)


### PR DESCRIPTION
## Why

`make fmt` broke on `main` right after the rhiza **v1.3.4** sync (#778) merged.

That sync rewrote `ruff.toml`'s `[lint.per-file-ignores]` upstream — to drop the
now-obsolete `.rhiza/tests/` glob — and the conflict was resolved by taking the
upstream side, per rhiza's rule that a template-owned file is the template's to own.
Collateral damage: this repo's local exemption went with it.

```toml
"src/pyhrp/*.py" = ["TRY003"]   # dropped by the sync
```

`ruff check` then flagged **9** `raise` sites that pass their message inline:

- `src/pyhrp/cluster.py` — 4 in `_child_clusters`
- `src/pyhrp/dendrogram.py` — 3 in `Dendrogram.__post_init__`, 1 in `_bisect_tree`,
  1 in the correlation-matrix type check

## What

Hoist each message into a local `msg` before raising — the idiom already used in
`plot.py:46`, `algos.py:122` and `dendrogram.py:183/189/203`, so this makes the
package internally consistent rather than introducing a new convention.

Exception types and message text are unchanged; there is no behaviour change.

## Why not just restore the ignore

`ruff.toml` is template-owned, so re-adding the exemption re-creates the exact
divergence that was just clobbered, and it would conflict again on every future
`/rhiza:update`. Fixing it in the source is sync-stable.

The general gap — no documented hook for project-local `per-file-ignores` that
survives a sync — is worth raising upstream on `jebel-quant/rhiza` separately.

## Verification

- `make fmt` — all 22 hooks pass (ruff check, ruff format, mypy strict, interrogate,
  bandit, markdownlint)
- `make test` — 123 passed, coverage **100%** (the edits sit on exception branches the
  suite asserts against, so this was worth confirming)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
