### PR TITLE
fix: make the tree traversals iterative so deep chains no longer overflow the stack

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,10 +22,13 @@ nav:
 
 # Tell mkdocstrings/griffe where the src-layout package lives so API docs build
 # by static analysis of the source, without an editable install. The rhiza book
-# command intentionally no longer installs the package editable
-# (see .rhiza/tests/integration/test_docs_targets.py::
-# test_default_book_command_does_not_use_editable_install), so a src-layout
+# command intentionally no longer installs the package editable, so a src-layout
 # project must point the handler at src/ itself.
+#
+# The check that pins that behaviour used to live at
+# .rhiza/tests/integration/test_docs_targets.py; rhiza v1.4.x moved the bundled
+# checks out of .rhiza/tests/ and into the pytest-rhiza package this repo pins in
+# [tool.rhiza-task], so cite the package rather than a path that no longer exists.
 plugins:
   - search
   - mkdocstrings:

--- a/src/pyhrp/algos.py
+++ b/src/pyhrp/algos.py
@@ -197,15 +197,33 @@ def _allocate(root: Cluster, assets: list[str], combine: Callable[[Cluster], Clu
     Returns:
         Cluster: The input node with portfolio weights assigned
     """
-    if root.is_leaf:
-        root.portfolio = Portfolio()
-        root.portfolio[assets[int(root.value)]] = 1.0
-        return root
+    # Iterative post-order rather than recursion: a chain-degenerate tree is as deep
+    # as the universe is wide, and recursing here capped the number of assets that
+    # could be allocated. Pass one collects nodes parent-before-child (validating
+    # each non-leaf as it goes, so a malformed tree still raises before any weight is
+    # written); reversing that order guarantees both children hold a portfolio before
+    # their parent combines them.
+    order: list[Cluster] = []
+    stack: list[Cluster] = [root]
+    while stack:
+        node = stack.pop()
+        order.append(node)
+        if not node.is_leaf:
+            left, right = node._child_clusters()
+            stack.append(left)
+            stack.append(right)
 
-    left, right = root._child_clusters()
-    root.left = _allocate(left, assets, combine)
-    root.right = _allocate(right, assets, combine)
-    return combine(root)
+    for node in reversed(order):
+        if node.is_leaf:
+            node.portfolio = Portfolio()
+            node.portfolio[assets[int(node.value)]] = 1.0
+        else:
+            # combine() replaces node.portfolio in place; the return value is the
+            # same node, which is why the recursive form's reassignment of
+            # root.left/root.right was always a no-op.
+            combine(node)
+
+    return root
 
 
 def _block_variance(portfolio: Portfolio, cov_np: np.ndarray, index: dict[str, int]) -> float:

--- a/src/pyhrp/cluster.py
+++ b/src/pyhrp/cluster.py
@@ -147,10 +147,21 @@ class Cluster(Node[int]):
         Returns:
             list[Cluster]: List of all leaf nodes reachable from this cluster
         """
-        if self.is_leaf:
-            return [self]
-        left, right = self._child_clusters()
-        return left.leaves + right.leaves
+        # Iterative for the same reason as Node.leaves, and still validating each
+        # non-leaf node through _child_clusters() so a malformed tree raises here
+        # rather than yielding a silently short leaf list.
+        result: list[Cluster] = []
+        stack: list[Cluster] = [self]
+        while stack:
+            node = stack.pop()
+            if node.is_leaf:
+                result.append(node)
+                continue
+            left, right = node._child_clusters()
+            # Right first, so the left subtree is emitted first.
+            stack.append(right)
+            stack.append(left)
+        return result
 
     def _child_clusters(self) -> tuple[Cluster, Cluster]:
         """Return the validated (left, right) child clusters of a non-leaf node.

--- a/src/pyhrp/dendrogram.py
+++ b/src/pyhrp/dendrogram.py
@@ -219,9 +219,35 @@ def _to_cluster(node: sch.ClusterNode) -> Cluster:
     Returns:
         Cluster: Equivalent node in our Cluster format.
     """
-    if node.left is not None and node.right is not None:
-        return Cluster(value=node.id, left=_to_cluster(node.left), right=_to_cluster(node.right))
-    return Cluster(value=node.id)
+    # Two passes instead of recursion. scipy's tree is as deep as the linkage is
+    # unbalanced -- single linkage chains, so depth grows with the asset count --
+    # and recursing here raised RecursionError before allocation was ever reached.
+    #
+    # Pass one collects nodes parent-before-child; reversing that order visits every
+    # child before its parent, which is what building bottom-up requires.
+    order: list[sch.ClusterNode] = []
+    stack: list[sch.ClusterNode] = [node]
+    while stack:
+        current = stack.pop()
+        order.append(current)
+        if current.left is not None and current.right is not None:
+            stack.append(current.left)
+            stack.append(current.right)
+
+    # Pass two builds each Cluster once its children exist. scipy assigns every
+    # node a unique id, so the id is a safe key for the partially built tree.
+    converted: dict[int, Cluster] = {}
+    for current in reversed(order):
+        if current.left is not None and current.right is not None:
+            converted[current.id] = Cluster(
+                value=current.id,
+                left=converted[current.left.id],
+                right=converted[current.right.id],
+            )
+        else:
+            converted[current.id] = Cluster(value=current.id)
+
+    return converted[node.id]
 
 
 def build_tree(

--- a/src/pyhrp/treelib.py
+++ b/src/pyhrp/treelib.py
@@ -58,14 +58,23 @@ class Node(Generic[T]):
         Returns:
             List[Node]: List of all leaf nodes
         """
-        if self.is_leaf:
-            return [self]
-
+        # Iterative depth-first walk with an explicit stack: the leaf order is the
+        # same left-to-right order the recursive form produced, but the traversal
+        # depth is bounded by the heap rather than by sys.getrecursionlimit(). A
+        # chain-degenerate cluster tree is as deep as it is wide, so recursing here
+        # put a ceiling on the number of assets the package could handle.
         result: list[Node[T]] = []
-        if self.left:
-            result.extend(self.left.leaves)
-        if self.right:
-            result.extend(self.right.leaves)
+        stack: list[Node[T]] = [self]
+        while stack:
+            node = stack.pop()
+            if node.is_leaf:
+                result.append(node)
+                continue
+            # Right first, so the left subtree is popped and emitted first.
+            if node.right is not None:
+                stack.append(node.right)
+            if node.left is not None:
+                stack.append(node.left)
 
         return result
 
@@ -109,12 +118,9 @@ class Node(Generic[T]):
         Returns:
             int: Total number of nodes
         """
-        size = 1  # Count this node
-        if self.left:
-            size += self.left.size
-        if self.right:
-            size += self.right.size
-        return size
+        # Counts via __iter__, which is already an iterative level-order walk, so
+        # this inherits its freedom from the recursion limit.
+        return sum(1 for _ in self)
 
     def __iter__(self) -> Iterator[Node[T]]:
         """Iterate through all nodes in the tree in level-order.

--- a/tests/pyhrp/test_algos.py
+++ b/tests/pyhrp/test_algos.py
@@ -26,7 +26,13 @@ from pyhrp.treelib import Node
 @st.composite
 def covariance_matrices(draw: st.DrawFn) -> pl.DataFrame:
     """Generate symmetric positive-definite covariance matrices."""
-    n_assets = draw(st.integers(min_value=2, max_value=8))
+    # Ceiling raised from 8 to 24. At 8 every generated tree was at most 8 deep, so
+    # no property could reach the deep-tree behaviour that the recursive traversals
+    # used to break on -- 100% branch coverage held while a 1200-asset universe
+    # crashed. Both properties build with single linkage, which chains, so 24 assets
+    # reach depths in the teens and above. Fixed-size chain regressions below cover
+    # the realistic-universe end, which is far too slow to generate 200 times.
+    n_assets = draw(st.integers(min_value=2, max_value=24))
     base = draw(
         hnp.arrays(
             dtype=np.float64,
@@ -398,3 +404,41 @@ def test_risk_parity_near_singular_covariance_matrix() -> None:
     assert np.all(weights >= 0.0)
     assert np.all(weights <= 1.0)
     assert float(weights.sum()) == pytest.approx(1.0, rel=1e-6, abs=1e-6)
+
+
+def _chain_correlation(n_assets: int) -> pl.DataFrame:
+    """Correlations decaying with index distance, which single linkage chains.
+
+    Single linkage merges nearest neighbours one at a time on this structure, so the
+    resulting tree is a chain of depth ``n_assets`` rather than the ``log2`` depth a
+    balanced tree would have. That is what makes it the right shape for exercising
+    deep-tree behaviour.
+    """
+    idx = np.arange(n_assets)
+    corr = 0.99 ** np.abs(idx[:, None] - idx[None, :]).astype(float)
+    np.fill_diagonal(corr, 1.0)
+    return pl.DataFrame(dict(zip([f"A{i}" for i in range(n_assets)], corr, strict=True)))
+
+
+def test_risk_parity_allocates_a_deep_chain_tree() -> None:
+    """risk_parity should allocate a chain-degenerate tree far deeper than the stack.
+
+    Regression test: single linkage on decaying correlations builds a tree whose depth
+    equals the asset count, and the recursive traversals raised RecursionError from
+    about 1000 assets -- an ordinary equity universe. 1500 exceeds that comfortably
+    while staying fast, since the traversals are now iterative.
+    """
+    n_assets = 1500
+    cor = _chain_correlation(n_assets)
+    root = build_tree(cor=cor, method="single", bisection=False).root
+
+    # Depth really is the asset count, i.e. the tree is a chain and not merely large.
+    assert len(root.levels) == n_assets
+
+    cluster = risk_parity(root=root, cov=cor)
+    weights = np.array(list(cluster.portfolio.weights.values()))
+
+    assert len(weights) == n_assets
+    assert np.all(np.isfinite(weights))
+    assert np.all(weights >= 0.0)
+    assert float(weights.sum()) == pytest.approx(1.0, rel=1e-9)

--- a/tests/pyhrp/test_dendrogram.py
+++ b/tests/pyhrp/test_dendrogram.py
@@ -33,7 +33,13 @@ from pyhrp.dendrogram import (
 @st.composite
 def covariance_matrices(draw: st.DrawFn) -> pl.DataFrame:
     """Generate symmetric positive-definite covariance matrices."""
-    n_assets = draw(st.integers(min_value=2, max_value=8))
+    # Ceiling raised from 8 to 24. At 8 every generated tree was at most 8 deep, so
+    # no property could reach the deep-tree behaviour that the recursive traversals
+    # used to break on -- 100% branch coverage held while a 1200-asset universe
+    # crashed. Both properties build with single linkage, which chains, so 24 assets
+    # reach depths in the teens and above. Fixed-size chain regressions below cover
+    # the realistic-universe end, which is far too slow to generate 200 times.
+    n_assets = draw(st.integers(min_value=2, max_value=24))
     base = draw(
         hnp.arrays(
             dtype=np.float64,
@@ -583,3 +589,38 @@ def test_dendrogram_one_over_n_wrapper_matches_function() -> None:
 
     assert via_wrapper == via_function
     assert sum(via_wrapper[0][1].values()) == pytest.approx(1.0)
+
+
+def _chain_correlation(n_assets: int) -> pl.DataFrame:
+    """Correlations decaying with index distance, which single linkage chains.
+
+    Produces a tree of depth ``n_assets`` instead of the ``log2`` depth of a balanced
+    tree, which is what makes it useful for exercising the tree traversals at depth.
+    """
+    idx = np.arange(n_assets)
+    corr = 0.99 ** np.abs(idx[:, None] - idx[None, :]).astype(float)
+    np.fill_diagonal(corr, 1.0)
+    return pl.DataFrame(dict(zip([f"A{i}" for i in range(n_assets)], corr, strict=True)))
+
+
+def test_build_tree_handles_a_deep_chain_tree() -> None:
+    """build_tree and the tree traversals should survive a chain far deeper than the stack.
+
+    Regression test: _to_cluster, Cluster.leaves and Node.size were recursive, so a
+    chain-degenerate tree raised RecursionError at roughly 1000 assets -- before any
+    allocation was reached. This asserts the whole read path over such a tree.
+    """
+    n_assets = 1500
+    cor = _chain_correlation(n_assets)
+
+    dendrogram = build_tree(cor=cor, method="single", bisection=False)
+    root = dendrogram.root
+
+    # A chain, not just a big tree: depth equals the number of assets.
+    assert len(root.levels) == n_assets
+    # Each formerly recursive traversal, at depth.
+    assert len(root.leaves) == n_assets
+    assert root.leaf_count == n_assets
+    assert root.size == 2 * n_assets - 1
+    assert dendrogram.assets == cor.columns
+    assert sorted(dendrogram.names) == sorted(cor.columns)


### PR DESCRIPTION
## The bug

Single linkage merges nearest neighbours one pair at a time, so the tree it builds is a **chain** — depth equals the asset count, not `log2` of it. Four traversals recursed over that depth and raised `RecursionError` from roughly **1000 assets**, an ordinary equity universe, *before allocation was ever reached*:

| Function | Module |
| --- | --- |
| `_to_cluster` | `dendrogram.py` — converting scipy's `ClusterNode` tree |
| `Cluster.leaves` | `cluster.py` |
| `Node.leaves` | `treelib.py` |
| `Node.size` | `treelib.py` |

## The fix

All four are now iterative — an explicit stack, or (for `size`) the already-iterative level-order `__iter__`.

Behaviour is unchanged:

- **Leaf order** is preserved: pushing the right child first means the left subtree pops and emits first.
- **Validation** is preserved: `_allocate` still routes every non-leaf through `_child_clusters()` during its collecting pass, so a malformed tree raises before any weight is written.
- `_allocate`'s two passes are collect-parent-before-child, then reverse — which guarantees both children hold a portfolio before their parent combines them. The recursive form's `root.left = _allocate(...)` reassignment was always a no-op, since `combine()` replaces `node.portfolio` in place and returns the same node.

## Why the tests didn't catch it

The Hypothesis strategies generated **at most 8 assets**, so no property could ever reach the depth that broke — 100% branch coverage held green while a 1200-asset universe crashed. Coverage measured which lines ran, not at what depth.

Two changes close that gap:

- The property ceiling moves from 8 to **24**, deep enough to reach depths in the teens on single linkage.
- New fixed **1500-asset chain regressions** cover the realistic-universe end, which is far too slow to generate 200 times. Each asserts `len(root.levels) == n_assets` first, so the test fails loudly if the fixture ever stops producing an actual chain.

## Also

Corrects the `mkdocs.yml` comment that cited `.rhiza/tests/integration/test_docs_targets.py` — rhiza v1.4.x moved the bundled checks into the `pytest-rhiza` package, so the cited path no longer exists.

## Gates

`make test` (125 passed, 100% coverage), `make typecheck` (ty + mypy strict), `make fmt` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of highly unbalanced and deeply nested portfolio trees.
  * Increased supported portfolio sizes without recursion-limit failures.
  * Preserved leaf ordering, node relationships, portfolio allocation, and normalization behavior.

* **Tests**
  * Added coverage for deep trees and portfolios containing up to 1,500 assets.
  * Expanded covariance and tree-generation test scenarios.

* **Documentation**
  * Updated installation and validation guidance to reflect current package behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->