### PR TITLE
chore: prune exclude entries the template no longer ships

### DIFF
--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -5,11 +5,7 @@ ref: v1.5.0
 include: []
 exclude:
 - SECURITY.md
-- .github/DISCUSSION_TEMPLATE
-- .github/ISSUE_TEMPLATE
 - .github/CONFIG.md
-- .github/workflows/rhiza_mutation.yml
-- .github/workflows/rhiza_fuzzing.yml
 templates:
 - legal
 profiles:

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -11,11 +11,8 @@ templates:
 # paths — where the file lands here, not where it sits in the template.
 exclude:
   # SECURITY.md makes factual claims about THIS repo's security posture (which scanners,
-  # which release protections). Only the repo knows which are true -- the template shipped a
-  # fuzzing claim that was false here -- so the file is owned here, not template-managed.
+  # which release protections). Only the repo knows which are true, so the file is owned
+  # here rather than template-managed.
   - SECURITY.md
-  - .github/DISCUSSION_TEMPLATE
-  - .github/ISSUE_TEMPLATE
+  # Contributor-facing GitHub meta doc: this repo's own, not the template's generic version.
   - .github/CONFIG.md
-  - .github/workflows/rhiza_mutation.yml
-  - .github/workflows/rhiza_fuzzing.yml


### PR DESCRIPTION
Prunes four `exclude:` entries that v1.5.0 made dead, in `.rhiza/template.yml` and the lock.

## Removed

| Path | Why it is dead |
| --- | --- |
| `.github/workflows/rhiza_fuzzing.yml` | workflow retired upstream (#1568) |
| `.github/workflows/rhiza_mutation.yml` | workflow retired upstream (#1572) |
| `.github/ISSUE_TEMPLATE` | bundle directory deleted (#1567) |
| `.github/DISCUSSION_TEMPLATE` | bundle directory deleted (#1566) |

Verified against the **v1.5.0 tree**, not just the release notes: none of the four appears anywhere under `bundles/`, and the bundled workflow set is now `benchmark`, `book`, `ci`, `codeql`, `devcontainer`, `docker`, `marimo`, `paper`, `quality_review`, `release`, `scorecard`, `weekly` — no fuzzing, no mutation.

An exclude entry for a path no bundle ships is dead config. It reads as a live decision, but dropping it would restore nothing.

## Kept

`SECURITY.md` and `.github/CONFIG.md` — v1.5.0 still ships both (`bundles/legal/SECURITY.md`, `bundles/github/.github/CONFIG.md`), so these two entries are still load-bearing. Their comments are trimmed to the reason that outlives the sync: `SECURITY.md`'s claims are the repo's to make. The fuzzing backstory is dropped now that it is settled.

## Notes

- The excluded-and-deleted files stay deleted. Nothing restores them, because the template has nothing left to restore.
- Config only — no workflow, source or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
