### PR TITLE
docs: cite pytest-rhiza instead of removed .rhiza/tests path

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,10 +25,9 @@ nav:
 # command intentionally no longer installs the package editable, so a src-layout
 # project must point the handler at src/ itself.
 #
-# The check that pins that behaviour used to live at
-# .rhiza/tests/integration/test_docs_targets.py; rhiza v1.4.x moved the bundled
-# checks out of .rhiza/tests/ and into the pytest-rhiza package this repo pins in
-# [tool.rhiza-task], so cite the package rather than a path that no longer exists.
+# The check pinning that behaviour ships with the pytest-rhiza package this repo
+# pins in [tool.rhiza-task] (rhiza v1.4.x moved the bundled checks out of
+# .rhiza/tests/ into that package).
 plugins:
   - search
   - mkdocstrings:


### PR DESCRIPTION
rhiza v1.4.x moved the bundled checks out of .rhiza/tests/ into the pytest-rhiza package this repo pins in [tool.rhiza-task]. Cite the package rather than a path that no longer exists.

Fixes #784

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the MkDocs guidance to reference the pinned `pytest-rhiza` package and its current task configuration.
  * Removed the outdated reference to the legacy documentation-target test path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->