### PR TITLE
docs: link the compiled paper from the book nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ docs_dir: docs
 
 nav:
   - Home: index.md
+  - Paper: paper/main.pdf
   - API Reference: api.md
   - Notebooks:
     - HRP: notebooks/hrp.html


### PR DESCRIPTION
Adds one line to `mkdocs.yml`:

```yaml
nav:
  - Home: index.md
  - Paper: paper/main.pdf      # <- new
```

`docs/paper/` already sits inside `docs_dir`, so the site build was copying the compiled
PDF to `paper/main.pdf` all along — it just wasn't linked from anywhere. This is the nav
entry the `paper` bundle's own README recommends, and it turns the PDF from a
reachable-if-you-know-the-URL asset into the durable published copy (the workflow artifact
expires after 30 days).

Verified locally: compiled the paper, built the book, and ran the real gate —
`rhiza-task book-nav` resolves `paper/main.pdf` against `_book/paper/main.pdf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the paper PDF to the documentation navigation under a new **Paper** entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->