### PR TITLE
build: derive the version from the git tag with hatch-vcs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,8 @@
 [project]
 name = "pyhrp"
-version = "2.3.3"
+# Derived from the git tag by hatch-vcs (see [tool.hatch.version]) rather than written
+# here, so the tag is the single source of truth and no commit can disagree with it.
+dynamic = ["version"]
 description = "Cluster-based portfolio allocation: HRP, Schur risk parity, and 1/N"
 authors = [{name = "Thomas Schmelzer", email = "thomas.schmelzer@gmail.com"}]
 readme = "README.md"
@@ -42,11 +44,23 @@ test = [
 ]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/pyhrp"]
+
+[tool.hatch.version]
+# Resolves [project].dynamic = ["version"] from `git describe`. Tags are vX.Y.Z and
+# hatch-vcs strips the leading "v" by default, so v2.3.3 builds 2.3.3; a commit off the
+# tag builds a PEP 440 dev version (2.3.4.dev64+g<sha>).
+#
+# This makes the build history-dependent: a shallow clone that cannot see the tag does
+# not fail, it silently builds 0.1.dev1+g<sha>. Every checkout in rhiza_release.yml uses
+# fetch-depth: 0, and its "Verify built distribution matches the tag" step parses the
+# filename in dist/ and fails the release unless it carries the tag -- nothing earlier
+# can catch a wrong derived version.
+source = "vcs"
 
 [tool.rhiza-task]
 # Settings for the task runner that replaced the synced make layer in rhiza v1.4.0.
@@ -75,8 +89,14 @@ typechecker = "both"
 
 # The retired quality.mk pinned `RHIZA_CHECKS_VERSION ?= 0.2.1`; the CLI defaults to
 # v0.2.0, so a bare migration would have *downgraded* the conformance checks -- the
-# drift the pin exists to prevent. Bumping it is a separate upgrade decision.
-pytest-rhiza = "pytest-rhiza @ git+https://github.com/Jebel-Quant/pytest-rhiza@v0.2.1"
+# drift the pin exists to prevent.
+#
+# Raised v0.2.1 -> 0.6.0 when [project].version became dynamic. Every release up to and
+# including 0.5.0 reads `project["version"]` unconditionally, so a derived version fails
+# test_version_follows_semver (empty string against the semver regex) and the git-tag
+# comparison (InvalidVersion on ""). 0.6.0 is the first release that asks whether the
+# version is dynamic and skips those two assertions; there is no older version to pin.
+pytest-rhiza = "pytest-rhiza==0.6.0"
 
 # Not set, on purpose:
 #   source-folder      -- the default `src` is already this repo's layout.
@@ -115,6 +135,12 @@ extend_exclude = [".rhiza"]
 # No `current_version` here on purpose — bump-my-version reads [project].version
 # natively, and a second copy only drifts once it goes stale.
 [tool.bumpversion]
+# No current_version and no [[tool.bumpversion.files]] entry: there is no longer a
+# version written anywhere to rewrite. [project].version is dynamic (see
+# [tool.hatch.version]), so the tag alone decides what gets built and a release is a
+# tag, not an edit. The table stays because bump-my-version still has to *discover* a
+# config -- from a path it never reads it falls back to `git describe` -- and because
+# the settings below still bind if it is run.
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:[-]?(?P<release>[a-z]+)[\\.]?(?P<pre_n>\\d+))?(?:\\+build\\.(?P<build_n>\\d+))?"
 serialize = [
     "{major}.{minor}.{patch}-{release}.{pre_n}+build.{build_n}",
@@ -149,8 +175,3 @@ values = [
 # Anchored to the [project] table on purpose. `search`/`replace` are applied to
 # EVERY occurrence in the file, so the obvious `version = "{current_version}"`
 # also rewrites any [tool.*] table that happens to share the current number.
-[[tool.bumpversion.files]]
-filename = "pyproject.toml"
-regex = true
-search = '(?ms)^\[project\]((?:(?!^\[)[\s\S])*?)^version = "{current_version}"'
-replace = '[project]\1version = "{new_version}"'

--- a/uv.lock
+++ b/uv.lock
@@ -914,7 +914,6 @@ wheels = [
 
 [[package]]
 name = "pyhrp"
-version = "2.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
`[project].version` was written as `2.3.3` and had to be kept in step with the tag by hand. This makes the **tag the single source of truth**, so no commit can disagree with it.

The pytest-rhiza pin moves from the `v0.2.1` git ref to `0.6.0`.

Also drops the `[[tool.bumpversion.files]]` entry: it rewrote `[project].version`, which no longer exists, and `ignore_missing_version = false` would have turned that into a hard failure on the next bump. The `[tool.bumpversion]` table itself stays so bump-my-version still *discovers* a config rather than falling back to `git describe`.

## What changed

- `[project].version` → `dynamic = ["version"]`, resolved by **hatch-vcs** from `git describe`.
- `[build-system]` gains `hatch-vcs`; `[tool.hatch.version]` sets `source = "vcs"`.
- `pytest-rhiza` pinned to **0.6.0**. Not optional: every release up to and including 0.5.0 reads `project["version"]` unconditionally, so a derived version fails `test_version_follows_semver` (empty string against the semver regex) and the git-tag comparison (`InvalidVersion` on `""`). 0.6.0 is the first release that asks whether the version is dynamic and skips those assertions.
- `uv.lock` drops the `version` field from this project's own entry.

## Verified

A clean clone tagged `v9.9.9` builds exactly `9.9.9` — the `v` stripped, no dev or local suffix — which is what `rhiza_release.yml`'s built-distribution filename check requires. Full test suite passes.

## Note

`uv sync` now rebuilds the project on every invocation: on a dirty tree hatch-vcs appends a date marker, so the version changes as the tree is edited.

A shallow clone that cannot see the tag does **not** fail — it silently builds `0.1.dev1+g<sha>`. Every checkout in `rhiza_release.yml` uses `fetch-depth: 0`, and the built-distribution check is the backstop.

---
No gates were run beyond the test suite; use `/rhiza:quality` for a scorecard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Project versions are now determined from Git tags during builds.
  * Updated the test tooling dependency to the released 0.6.0 version.
  * Simplified version-management configuration to reflect the automated versioning workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->